### PR TITLE
Fix query_string filters

### DIFF
--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -129,14 +129,10 @@ module Stretchy
             end
           end unless or_filters.blank?
 
-          # structure.bool do
-            # structure.must do
-              query_filters.each do |f|
-                structure.child! do
-                  structure.set! f[:name], extract_filters(f[:name], f[:args])
-                end
-              # end
-            # end
+          query_filters.each do |f|
+            structure.child! do
+              structure.set! f[:name], extract_filters(f[:name], f[:args])
+            end
           end unless query_filters.blank?
         end
       end

--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -111,6 +111,7 @@ module Stretchy
           end unless missing_bool_query? && missing_query_filter?
 
 
+
           structure.query_string do
             structure.extract! query_string_options, *query_string_options.keys
             structure.query query_strings
@@ -128,14 +129,14 @@ module Stretchy
             end
           end unless or_filters.blank?
 
-          structure.bool do
-            structure.must do
+          # structure.bool do
+            # structure.must do
               query_filters.each do |f|
                 structure.child! do
                   structure.set! f[:name], extract_filters(f[:name], f[:args])
                 end
-              end
-            end
+              # end
+            # end
           end unless query_filters.blank?
         end
       end
@@ -162,18 +163,6 @@ module Stretchy
               structure.set! highlight, extract_highlighter(highlight)
             end
           end
-        end
-      end
-
-      def build_filters
-        filters.each do |f|
-          structure.filter extract_filters(f[:name], f[:args])
-        end
-      end
-
-      def build_or_filters
-        or_filters.each do |f|
-          structure.filter extract_filters(f[:name], f[:args])
         end
       end
 

--- a/lib/stretchy/relations/query_methods.rb
+++ b/lib/stretchy/relations/query_methods.rb
@@ -266,7 +266,7 @@ module Stretchy
           #TODO: Remove duplication with: /activerecord/lib/active_record/sanitization.rb:113
           values = Hash === other.first ? other.first.values : other
 
-          values.grep(Elasticsearch::Persistence::Relation) do |rel|
+          values.grep(Stretchy::Relation) do |rel|
             self.bind_values += rel.bind_values
           end
 

--- a/spec/stretchy/query_builder_spec.rb
+++ b/spec/stretchy/query_builder_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-# require 'stretchy/relations/query_builder'
 
 describe Stretchy::Relations::QueryBuilder do
   let(:values) { { aggregation: {categories: { field: 'category', size: 10 }}, filter: { term: { status: 'active' } } } }
@@ -73,7 +72,7 @@ describe Stretchy::Relations::QueryBuilder do
             let(:filters) { {filter: [name: :active, args: {term: {status: :active}}]} }
     
             it 'builds the query structure' do
-                expect(subject.send(:build_query)[:bool][:filter][:bool][:must]).to include({active: {term: {status: :active}}}.with_indifferent_access)
+                expect(subject.send(:build_query)[:bool][:filter]).to include({active: {term: {status: :active}}}.with_indifferent_access)
             end
     
         end

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -132,6 +132,18 @@ describe "QueryMethods" do
                     expect(described_class.routing('123').first).to be_a(described_class)
                 end
             end
+
+            context 'query string' do
+                it 'filter with query string' do
+                    result = described_class.filter(:query_string, {query: "Mia OR Isabella", default_field: "name"} )
+                    expect(result.map(&:name)).to include("Mia Rodriguez", "Isabella Lewis")
+                end
+
+                it 'returns hits' do
+                    result = described_class.query_string("gender:male", default_field: "name")
+                    expect(result.map(&:gender)).to all(eq('male') )
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Removes ["bool"]["must"] as it is no longer supported or ignored within filters. 

```ruby
Model.filter(:query_string, {query: 'gender:female', default_field: 'gender'})

#=>  {"query"=>{"bool"=>{"filter"=>[{"query_string"=>{"query"=>"flagged: false", "default_field"=>"body"}}]}}}
```