### PR TITLE
Fix Scope overwriting clauses in some cases #20

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -24,7 +24,7 @@ print "\t    " * 7
 print Rainbow(" v#{Stretchy::VERSION}").white.faint
 print "\n\n"
 
-ActiveSupport::Notifications.subscribe 'search.elasticsearch' do |name, start, finish, id, payload|
+ActiveSupport::Notifications.subscribe 'search.stretchy' do |name, start, finish, id, payload|
    message = [
       Rainbow("  #{payload[:klass]}").bright, 
       "(#{(finish.to_time - start.to_time).round(2)}ms)",

--- a/lib/rails/instrumentation/publishers.rb
+++ b/lib/rails/instrumentation/publishers.rb
@@ -14,7 +14,7 @@ module Rails
                 end
 
                 def search_with_instrumentation!(query_or_definition, options={})
-                    ActiveSupport::Notifications.instrument "search.elasticsearch", 
+                    ActiveSupport::Notifications.instrument "search.stretchy", 
                       name: "Search", 
                       klass: self.base_class.to_s,
                       search: {index: self.index_name, body: query_or_definition }.merge(options) do

--- a/lib/rails/instrumentation/railtie.rb
+++ b/lib/rails/instrumentation/railtie.rb
@@ -2,27 +2,21 @@ module Stretchy
   module Instrumentation
 
     class Railtie < ::Rails::Railtie
-      include ActionView::Helpers::NumberHelper
-      def time_diff(start, finish)
-        begin
-          ((finish.to_time - start.to_time) * 1000).to_s(:rounded, precision: 5, strip_insignificant_zeros: true)
-        rescue
-          number_with_precision((finish.to_time - start.to_time) * 1000, precision: 5, strip_insignificant_zeros: true)
-        end
-      end
 
-      ActiveSupport::Notifications.subscribe 'query.elasticsearch' do |name, start, finish, id, payload|
-        ::Rails.logger.debug(["  #{payload[:name]}".bright, "(#{time_diff(start,finish)}ms)",payload[:query]].join(" ").color(:yellow))
-      end
+      require 'rails/instrumentation/publishers'
+      ActiveSupport::Notifications.subscribe 'search.stretchy' do |name, start, finish, id, payload|
+        message = [
+           Rainbow("  #{payload[:klass]}").bright, 
+           "(#{(finish.to_time - start.to_time).round(2)}ms)",
+           Stretchy::Utils.to_curl(payload[:klass].constantize, payload[:search])
+        ].join(" ")
+        ::Rails.logger.debug(Rainbow(message).color(:yellow))
+     end
 
-      ActiveSupport::Notifications.subscribe 'cache.query.elasticsearch' do |name, start, finish, id, payload|
-        ::Rails.logger.debug(["  #{payload[:name]}".bright, "CACHE".color(:mediumpurple).bright ,"(#{time_diff(start,finish)}ms)", payload[:query]].join(" ").color(:yellow))
-      end
-
-      initializer 'stretchy.set_defaults' do
-        config.elasticsearch_cache_store = :redis_store
-        config.elasticsearch_expire_cache_in = 15.minutes
-      end
+      # initializer 'stretchy.set_defaults' do
+      #   config.elasticsearch_cache_store = :redis_store
+      #   config.elasticsearch_expire_cache_in = 15.minutes
+      # end
 
     end
   end

--- a/lib/stretchy.rb
+++ b/lib/stretchy.rb
@@ -3,10 +3,8 @@ require 'zeitwerk'
 require 'amazing_print'
 require 'rainbow'
 require 'jbuilder'
-# require 'elasticsearch/rails'
 require 'elasticsearch/model'
 require 'elasticsearch/persistence'
-# require 'active_support/concern' 
 require 'active_model'
 require 'active_support/all'
 require 'active_model/type/array'
@@ -16,18 +14,37 @@ ActiveModel::Type.register(:array, ActiveModel::Type::Array)
 ActiveModel::Type.register(:hash, ActiveModel::Type::Hash)
 
 require_relative "stretchy/version"
-require_relative "stretchy/instrumentation/railtie" if defined?(Rails)
+require_relative "rails/instrumentation/railtie" if defined?(Rails)
 
 module Stretchy
   module Errors
     class QueryOptionMissing < StandardError; end
   end
 
+  class Configuration
+
+    attr_accessor :client
+
+    def initialize
+        @client = Elasticsearch::Client.new url: 'http://localhost:9200'
+    end
+
+  end
+
   class << self
     def logger
       @logger ||= Logger.new(STDOUT)
     end
+
+    def configuration
+        @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
   end
+
 
 end
 

--- a/lib/stretchy/delegation/gateway_delegation.rb
+++ b/lib/stretchy/delegation/gateway_delegation.rb
@@ -33,7 +33,7 @@ module Stretchy
       end
 
       def gateway(&block)
-          @gateway ||= Stretchy::Repository.create(index_name: index_name, klass: base_class)
+          @gateway ||= Stretchy::Repository.create(client: Stretchy.configuration.client, index_name: index_name, klass: base_class)
           block.arity < 1 ? @gateway.instance_eval(&block) : block.call(@gateway) if block_given?
           @gateway
       end

--- a/lib/stretchy/scoping.rb
+++ b/lib/stretchy/scoping.rb
@@ -13,13 +13,13 @@ module Stretchy
       end
 
       def current_scope
-          # ScopeRegistry.new.registry[:current_scope][base_class.to_s]
-          ScopeRegistry.new.value_for(:current_scope, base_class.to_s)
+          ScopeRegistry.new.registry[:current_scope][base_class.to_s]
+          # ScopeRegistry.value_for(:current_scope, base_class.to_s)
       end
 
       def current_scope=(scope) #:nodoc:
-        # ScopeRegistry.new.registry[:current_scope][base_class.to_s] = scope
-        ScopeRegistry.new.set_value_for(:current_scope, base_class.to_s, scope)
+        ScopeRegistry.new.registry[:current_scope][base_class.to_s] = scope
+        # ScopeRegistry.set_value_for(:current_scope, base_class.to_s, scope)
       end
     end
 

--- a/lib/stretchy/scoping/scope_registry.rb
+++ b/lib/stretchy/scoping/scope_registry.rb
@@ -6,20 +6,20 @@ module Stretchy
 
             VALID_SCOPE_TYPES = [:current_scope, :ignore_default_scope]
 
-            def initialize
-                @registry = Hash.new { |hash, key| hash[key] = {} }
-            end
+            # def initialize
+                self.registry = Hash.new { |hash, key| hash[key] = {} }
+            # end
 
             # Obtains the value for a given +scope_name+ and +variable_name+.
-            def value_for(scope_type, variable_name)
+            def self.value_for(scope_type, variable_name)
                 raise_invalid_scope_type!(scope_type)
-                @registry[scope_type][variable_name]
+                self.registry[scope_type][variable_name]
             end
 
             # Sets the +value+ for a given +scope_type+ and +variable_name+.
-            def set_value_for(scope_type, variable_name, value)
+            def self.set_value_for(scope_type, variable_name, value)
                 raise_invalid_scope_type!(scope_type)
-                @registry[scope_type][variable_name] = value
+                self.registry[scope_type][variable_name] = value
             end
 
             private

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stretchy
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -9,9 +9,8 @@ class Post < Stretchy::Record
 
     # Scopes
     scope :flagged, -> { where(flagged: true) }
-    scope :tags, -> (size=10, tags) { puts "tags: #{tags}"
-        puts "size: #{size}"
-    }
+    scope :full, -> { where(body: 'full') }
+
     mapping do
         indexes :title, type: 'string', analyzer: 'english'
         indexes :body, type: 'string', analyzer: 'english'

--- a/spec/stretchy/configuration_spec.rb
+++ b/spec/stretchy/configuration_spec.rb
@@ -8,15 +8,20 @@ describe Stretchy::Configuration do
         expect(client[:port]).to eq(9200)
     end
 
+    let(:model) do
+        class TestModel < Stretchy::Record
+        end
+        TestModel
+    end
+
     it 'can configure client' do
         Stretchy.configure do |config|
             config.client = Elasticsearch::Client.new url: 'http://localhost:92929'
         end
-        require 'models/post'
 
         expect(Stretchy.configuration.client.transport.transport.hosts.first[:host]).to eq('localhost')
         expect(Stretchy.configuration.client.transport.transport.hosts.first[:port]).to eq(92929)
-        expect(Post.gateway.client.transport.transport.hosts.first[:port]).to eq(92929)
+        expect(model.gateway.client.transport.transport.hosts.first[:port]).to eq(92929)
 
     end
 

--- a/spec/stretchy/configuration_spec.rb
+++ b/spec/stretchy/configuration_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Stretchy::Configuration do
+
+    it 'has a default host' do
+        client = Stretchy.configuration.client.transport.transport.hosts.first
+        expect(client[:host]).to eq('localhost')
+        expect(client[:port]).to eq(9200)
+    end
+
+    it 'can configure client' do
+        Stretchy.configure do |config|
+            config.client = Elasticsearch::Client.new url: 'http://localhost:92929'
+        end
+        require 'models/post'
+
+        expect(Stretchy.configuration.client.transport.transport.hosts.first[:host]).to eq('localhost')
+        expect(Stretchy.configuration.client.transport.transport.hosts.first[:port]).to eq(92929)
+        expect(Post.gateway.client.transport.transport.hosts.first[:port]).to eq(92929)
+
+    end
+
+end

--- a/spec/stretchy/record_spec.rb
+++ b/spec/stretchy/record_spec.rb
@@ -146,6 +146,11 @@ describe Stretchy::Record do
             expect(described_class.all.build(title: 'neat')).to be_a(described_class)
           end
 
+          it 'chains scopes' do
+            expected = {"query"=>{"bool"=>{"must"=>[{"term"=>{"title"=>"goats"}}, {"term"=>{"flagged"=>true}}, {"term"=>{"body"=>"full"}}]}}} 
+            expect(described_class.where(title: 'goats').flagged.full.to_elastic).to eq(expected)
+          end
+
           it 'returns as json' do
             expect(described_class.all.as_json).to be_a(Array)
             expect(described_class.all.as_json.first).to be_a(Hash)

--- a/stretchy-model.gemspec
+++ b/stretchy-model.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ["lib", "stretchy-model/lib"]
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/stretchy-model/lib/stretchy-model.rb
+++ b/stretchy-model/lib/stretchy-model.rb
@@ -1,0 +1,1 @@
+require_relative "../../lib/stretchy" 


### PR DESCRIPTION
This pull request fixes the issue with scope overwriting clauses in some cases. The issue caused the scope to be overwritten, resulting in incorrect query results. The fix ensures that scope registry is accessed correctly and the current_scope is avialable through the relation.

Additionally, the pull request includes some configuration changes and subscribers.