### PR TITLE
Update gem publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release Gem
+
+on:
+  push:
+    tags:
+      - 'v*'
+    paths: 
+      - 'lib/stretchy/version.rb'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish gem
+        uses: dawidd6/action-publish-gem@v1
+        with:
+          api_key: ${{secrets.RUBYGEMS_API_KEY}}
+          github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,20 @@ on:
 
 
 jobs:
+  spec:
+    uses: ./.github/workflows/spec.yml
+
   build:
     runs-on: ubuntu-latest
+    needs: spec
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Publish gem
-        uses: dawidd6/action-publish-gem@v1
-        with:
-          api_key: ${{secrets.RUBYGEMS_API_KEY}}
-          github_token: ${{secrets.GITHUB_TOKEN}}
+        if: contains(github.ref, 'refs/tags/v')
+        uses: cadwallion/publish-rubygems-action@master
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release Gem
 
 on:
   push:
+    branches: 
+      - main
     tags:
       - 'v*'
     paths: 
@@ -9,12 +11,12 @@ on:
 
 
 jobs:
-  spec:
-    uses: ./.github/workflows/spec.yml
+  # spec:
+    # uses: ./.github/workflows/spec.yml
 
   build:
     runs-on: ubuntu-latest
-    needs: spec
+    # needs: spec
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,6 +1,7 @@
 name: Ruby CI
 
 on: 
+  workflow_call: 
   pull_request:
 
 jobs:
@@ -41,17 +42,6 @@ jobs:
   opensearch:
   
       runs-on: ${{matrix.os}}-latest
-      # services: 
-      #   opensearch: 
-      #     image: opensearchproject/opensearch:2
-      #     ports: 
-      #       - 9200:9200
-      #     env:
-      #       discovery.type: single-node
-      #       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
-      #       DISABLE_INSTALL_DEMO_CONFIG: true
-      #       DISABLE_SECURITY_PLUGIN: true
-      #       bootstrap.memory_lock: true
 
       strategy:
         matrix:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -14,8 +14,6 @@ jobs:
         os: ['ubuntu']
         ruby: ['3.1', '2.7']
         elasticsearch: ['7.x-SNAPSHOT', '8.12.2']
-        # opensearch: ['2.12.0']
-
 
     steps:
       - uses: actions/checkout@v4

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ task default: %i[]
 
 require 'octokit' 
 require 'versionomy'
+require 'rainbow'
 
 def determine_current_version
   # Load current version
@@ -12,9 +13,9 @@ def determine_current_version
   current_version = Versionomy.parse(Stretchy::VERSION)
 end
 
-def determine_new_version(version=nil)
+def determine_new_version(version)
   # Load current version
-  current_version = version || determine_current_version
+  current_version = determine_current_version
 
   # Determine new version
   case version.to_sym
@@ -25,7 +26,7 @@ def determine_new_version(version=nil)
   when :patch
     current_version.bump(:tiny)
   else
-    Versionomy.parse(version)
+    version =~ /\Av\d+\.\d+\.\d+\z/ ? Versionomy.parse(version) : current_version
   end
 end
 
@@ -65,6 +66,7 @@ namespace :publish do
   
     old_version = determine_current_version
     new_version = determine_new_version(version)
+    puts Rainbow("Bumping version from #{old_version} to #{new_version}").green
     branch_name = create_release_branch(new_version, base_branch)
     begin
     update_version_file(new_version)

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,78 @@
 
 require "bundler/gem_tasks"
 task default: %i[]
+
+require 'octokit' 
+require 'versionomy'
+
+
+def determine_new_version(version)
+  # Load current version
+  load 'lib/stretchy/version.rb'
+  current_version = Versionomy.parse(Stretchy::VERSION)
+
+  # Determine new version
+  case version.to_sym
+  when :major
+    current_version.bump(:major)
+  when :minor
+    current_version.bump(:minor)
+  when :patch
+    current_version.bump(:tiny)
+  else
+    Versionomy.parse(version)
+  end
+end
+
+def create_release_branch(new_version, base_branch)
+  system("git fetch origin #{base_branch}")
+  branch_name = "release/v#{new_version}"
+  system("git checkout -b #{branch_name} #{base_branch}")
+  branch_name
+end
+
+def update_version_file(new_version)
+  # Update lib/stretchy/version.rb
+  File.open('lib/stretchy/version.rb', 'w') do |file|
+    file.puts "module Stretchy\n  VERSION = '#{new_version}'\nend"
+  end
+end
+
+def commit_and_push_changes(new_version, branch_name)
+  system("git add lib/stretchy/version.rb")
+  system("git commit -m 'Bump version to v#{new_version}'")
+  system("git push origin #{branch_name}")
+end
+
+def create_pull_request(new_version, base_branch, branch_name)
+  # Create a pull request
+  client = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'])
+  client.create_pull_request('theablefew/stretchy', base_branch, branch_name, "Release v#{new_version}")
+end
+
+namespace :publish do
+  desc "Create a release"
+  task :release, [:version, :base_branch] do |t, args|
+    args.with_defaults(version: :patch, base_branch: 'main')
+    version = args[:version]
+    base_branch = args[:base_branch]
+  
+    new_version = determine_new_version(version)
+    branch_name = create_release_branch(new_version, base_branch)
+    update_version_file(new_version)
+    commit_and_push_changes(new_version, branch_name)
+    create_pull_request(new_version, base_branch, branch_name)
+  end
+
+  task :major do
+    Rake::Task['publish:release'].invoke('major')
+  end
+
+  task :minor do
+    Rake::Task['publish:release'].invoke('minor')
+  end
+
+  task :patch do
+    Rake::Task['publish:release'].invoke('patch')
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,7 @@ def determine_new_version(version)
 end
 
 def create_release_branch(new_version, base_branch)
+  system("git stash save 'Changes before creating release branch'")
   system("git fetch origin #{base_branch}")
   branch_name = "release/v#{new_version}"
   system("git checkout -b #{branch_name} #{base_branch}")

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Stretchy
-  VERSION = "0.3.0"
+  VERSION = '0.3.1'
 end

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.3.3'
+  VERSION = '0.3.1'
 end

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.3.1'
+  VERSION = '0.3.0'
 end

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/stretchy-model.gemspec
+++ b/stretchy-model.gemspec
@@ -45,6 +45,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.21.2"
   spec.add_development_dependency "yard", "~> 0.9.36"
   spec.add_development_dependency "opensearch-ruby", "~> 3.0"
+  spec.add_development_dependency "octokit", "~> 4.20"
+  spec.add_development_dependency "versionomy", "~> 0.5.0"
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
This pull request updates the gem publishing workflow to include a new step for releasing the gem. It also adds a new workflow file, `release.yml`, which is triggered when a tag is pushed. The `build` job in the workflow checks out the code, and if the tag matches the pattern `v*`, it publishes the gem using the `cadwallion/publish-rubygems-action` action.