### PR TITLE
Allow optional v prefix for new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Publish gem
         uses: cadwallion/publish-rubygems-action@master
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.STRETCHY_PA_TOKEN}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
           RELEASE_COMMAND: rake release

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ def determine_new_version(version)
   when :patch
     current_version.bump(:tiny)
   else
-    version =~ /\Av\d+\.\d+\.\d+\z/ ? Versionomy.parse(version) : current_version
+    version =~ /\Av?\d+\.\d+\.\d+\z/ ? Versionomy.parse(version).to_s.gsub(/v/,'') : current_version
   end
 end
 


### PR DESCRIPTION
This pull request adds support for an optional "v" prefix when stating a new version. This allows users to specify version numbers with or without the "v" prefix, providing more flexibility in versioning.

`rake publish:release[v0.3.3]` or `rake publish:release[0.3.3]`