### PR TITLE
Fix Specifying default keyword fields #44 #43 #42

### DIFF
--- a/lib/stretchy/attributes.rb
+++ b/lib/stretchy/attributes.rb
@@ -1,0 +1,10 @@
+module Stretchy
+  module Attributes
+
+    def self.register!
+      ActiveModel::Type.register(:array, ActiveModel::Type::Array)
+      ActiveModel::Type.register(:hash, ActiveModel::Type::Hash)
+      ActiveModel::Type.register(:keyword, Stretchy::Attributes::Type::Keyword)
+    end
+  end
+end

--- a/lib/stretchy/attributes/transformers/keyword_transformer.rb
+++ b/lib/stretchy/attributes/transformers/keyword_transformer.rb
@@ -25,14 +25,16 @@ module Stretchy
           end
           
           def keyword?(arg)
-            attribute_types[arg.to_s].is_a?(Stretchy::Attributes::Type::Keyword)
+            attr = @attribute_types[arg.to_s] 
+            return false unless attr
+            attr.is_a?(Stretchy::Attributes::Type::Keyword)
           end
 
           def protected?(arg)
             Stretchy::Relations::AggregationMethods::AGGREGATION_METHODS.include?(arg.to_sym)
           end
           
-          def transform(item, *ignore)
+          def transform(item, *ignore) 
             item.each_with_object({}) do |(k, v), new_item|
               if ignore && ignore.include?(k)
                 new_item[k] = v
@@ -45,7 +47,7 @@ module Stretchy
               if new_value.is_a?(Hash)
                 new_value = transform(new_value)
               elsif new_value.is_a?(Array)
-                new_value = new_value.map { |i| i.is_a?(Hash) ? transform_keys_for_item(i) : i }
+                new_value = new_value.map { |i| i.is_a?(Hash) ? transform(i) : i }
               elsif new_value.is_a?(String) || new_value.is_a?(Symbol) 
                 new_value = "#{new_value}.keyword" if keyword?(new_value)
               end

--- a/lib/stretchy/attributes/transformers/keyword_transformer.rb
+++ b/lib/stretchy/attributes/transformers/keyword_transformer.rb
@@ -1,0 +1,82 @@
+module Stretchy
+  module Attributes
+    module Transformers
+      class KeywordTransformer
+
+          KEYWORD_AGGREGATION_KEYS = [:terms, :rare_terms, :significant_terms, :cardinality, :string_stats]
+
+          attr_reader :attribute_types
+
+          def initialize(attribute_types)
+            @attribute_types = attribute_types
+          end
+
+          def cast_value_keys
+            values.transform_values do |value|
+              case value
+              when Array
+                value.map { |item| transform_keys_for_item(item) }
+              when Hash
+                transform_keys_for_item(value)
+              else
+                value
+              end
+            end
+          end
+          
+          def keyword?(arg)
+            attribute_types[arg.to_s].is_a?(Stretchy::Attributes::Type::Keyword)
+          end
+
+          def protected?(arg)
+            Stretchy::Relations::AggregationMethods::AGGREGATION_METHODS.include?(arg.to_sym)
+          end
+          
+          def transform(item, *ignore)
+            item.each_with_object({}) do |(k, v), new_item|
+              if ignore && ignore.include?(k)
+                new_item[k] = v
+                next
+              end
+              new_key = (!protected?(k) && keyword?(k)) ? "#{k}.keyword" : k
+
+              new_value = v
+          
+              if new_value.is_a?(Hash)
+                new_value = transform(new_value)
+              elsif new_value.is_a?(Array)
+                new_value = new_value.map { |i| i.is_a?(Hash) ? transform_keys_for_item(i) : i }
+              elsif new_value.is_a?(String) || new_value.is_a?(Symbol) 
+                new_value = "#{new_value}.keyword" if keyword?(new_value)
+              end
+
+              new_item[new_key] = new_value
+            end
+          end
+
+          # If terms are used, we assume that the field is a keyword field
+          # and append .keyword to the field name
+          # {terms: {field: 'gender'}}
+          # or nested aggs
+          # {terms: {field: 'gender'}, aggs: {name: {terms: {field: 'position.name'}}}}
+          # should be converted to
+          # {terms: {field: 'gender.keyword'}, aggs: {name: {terms: {field: 'position.name.keyword'}}}}
+          # {date_histogram: {field: 'created_at', interval: 'day'}}
+          # TODO: There may be cases where we don't want to add .keyword to the field and there should be a way to override this
+          def assume_keyword_field(args={}, parent_match=false)
+            if args.is_a?(Hash)
+              args.each do |k, v|
+                if v.is_a?(Hash) 
+                  assume_keyword_field(v, KEYWORD_AGGREGATION_FIELDS.include?(k))
+                else
+                  next unless v.is_a?(String) || v.is_a?(Symbol)
+                  args[k] = ([:field, :fields].include?(k.to_sym) && v !~ /\.keyword$/ && parent_match) ? "#{v}.keyword" : v.to_s
+                end
+              end
+            end
+          end
+
+      end
+    end
+  end
+end

--- a/lib/stretchy/attributes/type/keyword.rb
+++ b/lib/stretchy/attributes/type/keyword.rb
@@ -1,0 +1,11 @@
+module Stretchy
+    module Attributes
+        module Type
+            class Keyword < ActiveModel::Type::String # :nodoc:
+                def type
+                    :keyword
+                end
+            end
+        end
+    end
+end

--- a/lib/stretchy/relation.rb
+++ b/lib/stretchy/relation.rb
@@ -162,7 +162,7 @@ module Stretchy
         #
         # @return [QueryBuilder] The query builder for the relation.
         def query_builder
-          Relations::QueryBuilder.new(values)
+          Relations::QueryBuilder.new(values, klass.attribute_types)
         end
 
     end

--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -2,9 +2,10 @@ module Stretchy
   module Relations
     class QueryBuilder
 
-      attr_reader :structure, :values
+      attr_reader :structure, :values, :attribute_types
 
-      def initialize(values)
+      def initialize(values, attribute_types = nil)
+        @attribute_types = attribute_types
         @structure = Jbuilder.new ignore_nil: true
         @values = values
       end
@@ -165,7 +166,7 @@ module Stretchy
       def build_aggregations
         structure.aggregations do
           aggregations.each do |agg|
-            structure.set! agg[:name], aggregation(agg[:name], agg[:args])
+            structure.set! agg[:name], aggregation(agg[:name], keyword_transformer.transform(agg[:args], :name))
           end
         end
       end
@@ -199,12 +200,22 @@ module Stretchy
       def as_must(q)
         _must = []
         q.each do |arg|
-          arg.each_pair { |k,v| _must << (v.is_a?(Array) ? {terms: Hash[k,v]} : {term: Hash[k,v]}) } if arg.class == Hash
-          _must << {term: Hash[[arg.split(/:/).collect(&:strip)]]} if arg.class == String
-          _must << arg.first if arg.class == Array
+          case arg
+          when Hash
+            arg = keyword_transformer.transform(arg)
+            arg.each_pair do |k,v| 
+              # If v is an array, we build a terms query otherwise a term query
+              _must << (v.is_a?(Array) ? {terms: Hash[k,v]} : {term: Hash[k,v]}) 
+            end
+          when String
+            _must << {term: Hash[[arg.split(/:/).collect(&:strip)]]}
+          when Array
+            _must << arg.first
+          end
         end
         _must.length == 1 ? _must.first : _must
       end
+
 
       def as_query_string(q)
         _and = []
@@ -260,6 +271,9 @@ module Stretchy
         end
       end
 
+      def keyword_transformer
+        @keyword_transformer ||= Stretchy::Attributes::Transformers::KeywordTransformer.new(@attribute_types)
+      end
     end
   end
 end

--- a/spec/stretchy/attributes/transformers/keyword_transformer_spec.rb
+++ b/spec/stretchy/attributes/transformers/keyword_transformer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Stretchy::Attributes::Transformers::KeywordTransformer do
+
+  let(:values) { 
+    { 
+      where: [{ title: 'Lilly' }], 
+      filter_query: [{ name: :terms, args: { term: 'value' } }],
+      aggregation: [{:args=>{:terms=>{:field=>"terms"}}, :name=>:terms}],
+      size: 1000
+    }
+  }
+
+  let (:model) do
+    class MyModel < Stretchy::Record
+      attribute :title, :keyword
+    end
+    MyModel
+  end
+
+
+  it 'converts keyword attribute names to .keyword' do
+    transformed_keywords = values[:where].map do |arg|
+      described_class.new(model.attribute_types).transform(arg)
+    end
+    expect(transformed_keywords).to eq([{ 'title.keyword' => 'Lilly' }])
+  end
+
+  it 'does not transform protected parameters keys to .keyword' do
+    model.attribute :terms, :keyword
+    transformed_keywords = values[:aggregation].map do |arg|
+      described_class.new(model.attribute_types).transform(arg, :name)
+    end
+    expect(transformed_keywords).to eq([{ name: :terms, args: { terms: { field: 'terms.keyword' } } }])
+  end
+
+  it 'does not convert aggregation or filter name values to .keyword' do
+    transformed_keywords = values[:filter_query].map do |arg|
+      described_class.new(model.attribute_types).transform(arg, :name)
+    end
+    expect(transformed_keywords).to eq([{ name: :terms, args: { term: 'value' } }])
+  end
+
+  it 'handles nested hashes' do
+    values = [{ name: :terms, args: { terms: {field: 'value'}, aggs: { more_terms: { terms: { field: :title }}}}}]
+    transformed_keywords = values.map do |arg|
+      described_class.new(model.attribute_types).transform(arg, :name)
+    end
+    expect(transformed_keywords).to eq([{ name: :terms, args: { terms: { field: 'value' }, aggs: { more_terms: { terms: { field: 'title.keyword' }}}}}])
+  end
+
+end

--- a/spec/stretchy/relations/query_builder_spec.rb
+++ b/spec/stretchy/relations/query_builder_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe Stretchy::Relations::QueryBuilder do
   let(:values) { { aggregation: {categories: { field: 'category', size: 10 }}, filter: { term: { status: 'active' } } } }
-  subject { described_class.new(values) }
+  let(:attribute_types) { double('model', attribute_types: { "status": Stretchy::Attributes::Type::Keyword.new })}
+  before do
+    allow(attribute_types).to receive(:[])
+  end
+  subject { described_class.new(values, attribute_types) }
 
   describe '#aggregations' do
     it 'returns the aggregations value' do
@@ -25,7 +29,7 @@ describe Stretchy::Relations::QueryBuilder do
   describe '#where' do
     it 'returns the compacted where value' do
       multi_terms = {where: [{status: 'active'}, {category: 'ruby'}]}
-      expect(described_class.new(multi_terms).query).to eq(subject.send(:compact_where, multi_terms[:where]))
+      expect(described_class.new(multi_terms, attribute_types).query).to eq(subject.send(:compact_where, multi_terms[:where]))
     end
   end
 
@@ -41,7 +45,7 @@ describe Stretchy::Relations::QueryBuilder do
         end
 
         context 'when not missing bool query' do
-            let(:subject) { described_class.new(bool_query) }
+            let(:subject) { described_class.new(bool_query, attribute_types) }
 
             context 'when using where' do
                 let(:bool_query) { {where: [{status: :active}]}} 
@@ -98,6 +102,43 @@ describe Stretchy::Relations::QueryBuilder do
             subject = described_class.new(search_option: {routing: 'user_1'})
             query = subject.values[:search_option].with_indifferent_access
             expect(query).to eq({routing: 'user_1'}.with_indifferent_access)
+          end
+        end
+
+        context 'keywords' do
+          let(:model) do
+            class MyModel < Stretchy::Record
+              attribute :title, :keyword
+              attribute :status, :keyword
+              attribute :terms, :keyword
+              attribute :term, :keyword
+            end
+            MyModel
+          end
+          
+          let(:filters) { {filter_query: [name: :active, args: {term: {status: :active}}]} }
+
+          it 'converts aggregation keyword attribute names to .keyword' do
+            aggregation = {aggregation: [{ name: :terms, args: { terms: {field: 'value'}, aggs: { more_terms: { terms: { field: :title }}}}}]}
+            elastic_hash = described_class.new(aggregation, model.attribute_types).to_elastic
+            expect(elastic_hash).to eq({aggregations: {terms: {terms: {field: 'value'}, aggs: { more_terms: {terms: {field: 'title.keyword'}}}}}}.with_indifferent_access)
+          end
+
+          it 'converts filter keyword attribute names to .keyword' do
+            elastic_hash = described_class.new(filters, model.attribute_types).to_elastic
+            expect(elastic_hash).to eq({query: {bool: {filter: [{active: {term: {status: :active}}}]}}}.with_indifferent_access)
+          end
+
+          it 'converts where keyword attribute names to .keyword' do
+            where = {where: [{title: 'Lilly'}]}
+            elastic_hash = described_class.new(where, model.attribute_types).to_elastic
+            expect(elastic_hash).to eq({query: {bool: {must: {term: {'title.keyword' => 'Lilly'}}}}}.with_indifferent_access)
+          end
+
+          it 'converts must_not keyword attribute names to .keyword' do
+            must_not = {must_not: [{title: 'Lilly'}]}
+            elastic_hash = described_class.new(must_not, model.attribute_types).to_elastic
+            expect(elastic_hash).to eq({query: {bool: {must_not: {term: {'title.keyword' => 'Lilly'}}}}}.with_indifferent_access)
           end
         end
   end


### PR DESCRIPTION
This pull request fixes the issue of specifying default keyword fields in the codebase. It introduces a new attribute type called `:keyword` and a keyword transformer to handle the conversion of attribute names to `.keyword`. This change provides a clear and non-magical way to determine if a field should use `.keyword` by default when referenced. It also addresses the behavior of automatically assuming `.keyword` in certain cases, making the behavior more explicit and avoiding assumptions on the user's behalf.
