### PR TITLE
Fix issue with sort overriding default_sort_key

### DIFF
--- a/lib/stretchy/attributes/transformers/keyword_transformer.rb
+++ b/lib/stretchy/attributes/transformers/keyword_transformer.rb
@@ -31,6 +31,7 @@ module Stretchy
           end
 
           def protected?(arg)
+            return false if arg.nil?
             Stretchy::Relations::AggregationMethods::AGGREGATION_METHODS.include?(arg.to_sym)
           end
           

--- a/lib/stretchy/relations/finder_methods.rb
+++ b/lib/stretchy/relations/finder_methods.rb
@@ -9,7 +9,16 @@ module Stretchy
         end
 
         def first!
-          spawn.sort(Hash[default_sort_key, :asc]).spawn.size(1)
+          spawned = spawn
+          if spawned.order_values.length.zero? 
+            spawn.sort(Hash[default_sort_key, :asc]).spawn.size(1)
+          elsif spawned.order_values.length == 1
+            new_direction = Hash[spawned.order_values.first.keys.first, :asc] 
+            spawned.order_values = [] 
+            spawned.order(**new_direction).size(1)
+          elsif
+            spawn.size(1)
+          end
           self
         end
 
@@ -19,7 +28,16 @@ module Stretchy
         end
 
         def last!
-          spawn.sort(Hash[default_sort_key, :desc]).spawn.size(1)
+          spawned = spawn
+          if spawned.order_values.length.zero?
+            spawn.sort(Hash[default_sort_key, :desc]).spawn.size(1)
+          elsif spawned.order_values.length == 1
+              new_direction = Hash[spawned.order_values.first.keys.first, :desc]
+              spawned.order_values.clear 
+              spawned.order(new_direction).size(1)
+          else
+            spawn.size(1)
+          end
           self
         end
 

--- a/lib/stretchy/relations/finder_methods.rb
+++ b/lib/stretchy/relations/finder_methods.rb
@@ -12,12 +12,11 @@ module Stretchy
           spawned = spawn
           if spawned.order_values.length.zero? 
             spawn.sort(Hash[default_sort_key, :asc]).spawn.size(1)
-          elsif spawned.order_values.length == 1
-            new_direction = Hash[spawned.order_values.first.keys.first, :asc] 
-            spawned.order_values = [] 
-            spawned.order(**new_direction).size(1)
-          elsif
-            spawn.size(1)
+          elsif spawned.order_values.length >= 1
+            first_order_value = spawned.order_values.shift
+            new_direction = Hash[first_order_value.keys.first, :asc] 
+            spawned.order_values.unshift(new_direction)
+            spawned.size(1)
           end
           self
         end
@@ -31,12 +30,11 @@ module Stretchy
           spawned = spawn
           if spawned.order_values.length.zero?
             spawn.sort(Hash[default_sort_key, :desc]).spawn.size(1)
-          elsif spawned.order_values.length == 1
-              new_direction = Hash[spawned.order_values.first.keys.first, :desc]
-              spawned.order_values.clear 
-              spawned.order(new_direction).size(1)
-          else
-            spawn.size(1)
+          elsif spawned.order_values.length >= 1
+            first_order_value = spawned.order_values.shift
+            new_direction = Hash[first_order_value.keys.first, :desc] 
+            spawned.order_values.unshift(new_direction)
+            spawned.size(1)
           end
           self
         end

--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -150,7 +150,7 @@ module Stretchy
       end
 
       def build_sort
-        structure.sort sort.flatten #.inject(Hash.new) { |h,v| h.merge(v) }
+        structure.sort sort.map { |arg| keyword_transformer.transform(arg) }.flatten
       end
 
       def build_highlights

--- a/spec/models/resource.rb
+++ b/spec/models/resource.rb
@@ -1,11 +1,11 @@
 class Resource < Stretchy::Record
     index_name "resource_test"
 
-    attribute :name,                :string
-    attribute :email,               :string
+    attribute :name,                :keyword
+    attribute :email,               :keyword
     attribute :phone,               :string
     attribute :position,            :hash
-    attribute :gender,              :string
+    attribute :gender,              :keyword
     attribute :age,                 :integer
     attribute :income,              :integer
     attribute :income_after_raise,  :integer

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -184,6 +184,18 @@ describe "QueryMethods" do
                     query = subject.first!.to_elastic
                     expect(query).to eq({sort: [{'name.keyword': :asc}]}.with_indifferent_access)
                 end
+                
+                it 'changes first sort key to desc' do
+                    subject = described_class.sort(name: :asc, age: :desc)
+                    query = subject.last!.to_elastic
+                    expect(query[:sort]).to eq([{'name.keyword' => :desc}, {'age' => :desc}])
+                end
+
+                it 'changes first sort key to asc' do
+                    subject = described_class.sort(name: :desc, age: :desc)
+                    query = subject.first!.to_elastic
+                    expect(query[:sort]).to eq([{'name.keyword' => :asc}, {'age' => :desc}])
+                end
 
             end
 

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -163,7 +163,7 @@ describe "QueryMethods" do
 
                 it 'accepts fields as keyword arguments' do
                     result = described_class.order(age: :desc, name: :asc, created_at: {order: :desc, mode: :avg})
-                    expected = {:sort=>[{:age=>:desc}, {:name=>:asc}, {:created_at=>{:order=>:desc, :mode=>:avg}}]}
+                    expected = {:sort=>[{:age=>:desc}, {'name.keyword'=>:asc}, {:created_at=>{:order=>:desc, :mode=>:avg}}]}
                     expect(result.to_elastic).to eq(expected.with_indifferent_access)
                 end
 
@@ -172,6 +172,19 @@ describe "QueryMethods" do
                     expected = {:sort=>[{:age=>:desc}]}
                     expect(result.to_elastic).to eq(expected.with_indifferent_access)
                 end
+
+                it 'overrides default sort with last' do
+                    subject = described_class.sort(name: :asc)
+                    query = subject.last!.to_elastic
+                    expect(query).to eq({sort: [{'name.keyword': :desc}]}.with_indifferent_access)
+                end
+
+                it 'overrides default sort with first' do
+                    subject = described_class.sort(name: :asc)
+                    query = subject.first!.to_elastic
+                    expect(query).to eq({sort: [{'name.keyword': :asc}]}.with_indifferent_access)
+                end
+
             end
 
             context 'fields' do

--- a/spec/stretchy/relations/query_builder_spec.rb
+++ b/spec/stretchy/relations/query_builder_spec.rb
@@ -84,17 +84,19 @@ describe Stretchy::Relations::QueryBuilder do
         context 'sorting' do
           it 'accepts array of hashes' do
             sorts = [{created_at: :desc}, {title: :asc}]
-            subject = described_class.new(order: sorts)
+            subject = described_class.new({order: sorts}, attribute_types)
             query = subject.to_elastic
             expect(query).to eq({sort: sorts}.with_indifferent_access)
           end
         
           it 'accepts options' do 
             sorts = [{price: { order: :desc, mode: :avg}}]
-            subject = described_class.new(order: sorts)
+            subject = described_class.new({order: sorts}, attribute_types)
             query = subject.to_elastic
             expect(query).to eq({sort: sorts}.with_indifferent_access)
           end
+
+
         end
 
         context 'search options' do


### PR DESCRIPTION
This pull request fixes the issue where the sort method was not properly overriding the default_sort_key. The changes in the code ensure that the sort method correctly overrides the default_sort_key when specified. 

If a more sort keys exist that aren't `default_sort_key` then it changes the direction of the first sort argument. 

This resolves issue #39.