### PR TITLE
Version bump to 0.4.0

### DIFF
--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.3.3'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
This pull request updates the version of the stretchy-model library to 0.4.0.