### PR TITLE
More convenience to `.where`

### DIFF
--- a/lib/stretchy/querying.rb
+++ b/lib/stretchy/querying.rb
@@ -6,7 +6,7 @@ module Stretchy
     delegate *Stretchy::Relations::AggregationMethods::AGGREGATION_METHODS, to: :all
 
     delegate :skip_callbacks, :routing, :search_options, to: :all
-    delegate :must, :must_not, :should, :where_not, :where, :filter_query, :query_string, to: :all
+    delegate :must, :must_not, :should, :where_not, :where, :filter_query, :query_string, :regexp, to: :all
 
     def fetch_results(es)
       unless es.count?

--- a/lib/stretchy/record.rb
+++ b/lib/stretchy/record.rb
@@ -28,6 +28,7 @@ module Stretchy
                 include Stretchy::Common
                 include Stretchy::Scoping
                 include Stretchy::Utils
+                include Stretchy::SharedScopes
 
                 extend Stretchy::Delegation::DelegateCache
                 extend Stretchy::Querying

--- a/lib/stretchy/relations/query_methods.rb
+++ b/lib/stretchy/relations/query_methods.rb
@@ -18,7 +18,8 @@ module Stretchy
         :filter_query, 
         :or_filter,
         :extending,
-        :skip_callbacks
+        :skip_callbacks,
+        :regexp
       ]
 
       SINGLE_VALUE_METHODS = [:size]
@@ -173,6 +174,16 @@ module Stretchy
       #          }
       #        }
       #
+      # .where acts as a convienence method for adding conditions to the query. It can also be used to add
+      # range , regex, terms, and id queries through shorthand parameters.
+      #
+      # @example
+      #   Model.where(price: {gte: 10, lte: 20})
+      #   Model.where(age: 19..33)
+      #   Model.where(color: /gr(a|e)y/)
+      #   Model.where(id: [10, 22, 18])
+      #   Model.where(names: ['John', 'Jane'])
+      #
       # @return [ActiveRecord::Relation, WhereChain] a new relation, which reflects the conditions, or a WhereChain if opts is :chain
       # @see #must
       def where(opts = :chain, *rest)
@@ -181,6 +192,21 @@ module Stretchy
         elsif opts.blank?
           self
         else
+          rest.each do |key, value|
+            case value
+            when Range
+              between(value, key)
+            when Hash
+              filter_query(:range, key => value) if value.keys.any? { |k| [:gte, :lte, :gt, :lt].include?(k) }
+            when Regexp
+              regexp(key, value)
+            when Array
+              terms(key, value)
+            else
+              term(key, value)
+            end
+          end
+
           spawn.where!(opts, *rest)
         end
       end
@@ -199,6 +225,38 @@ module Stretchy
       # @see #where
       alias :must :where
 
+      # Adds a regexp condition to the query.
+      # 
+      # @param field [Hash] the field to filter by and the Regexp to match
+      # @param opts [Hash] additional options for the regexp query
+      #     - :flags [String] the flags to use for the regexp query (e.g. 'ALL')
+      #     - :use_keyword [Boolean] whether to use the .keyword field for the regexp query. Default: true
+      #     - :case_insensitive [Boolean] whether to use case insensitive matching. If the regexp has ignore case flag `/regex/i`, this is automatically set to true
+      #     - :max_determinized_states [Integer] the maximum number of states that the regexp query can produce
+      #     - :rewrite [String] the rewrite method to use for the regexp query
+      #     
+      # 
+      # @example
+      #  Model.regexp(:name, /john|jane/)
+      #  Model.regexp(:name, /john|jane/i)
+      #  Model.regexp(:name, /john|jane/i, flags: 'ALL')
+      #  
+      # @return [Stretchy::Relation] a new relation, which reflects the regexp condition
+      # @see #where
+      def regexp(args)
+        spawn.regexp!(args)
+      end
+
+      def regexp!(args) # :nodoc:
+        args = args.to_a
+        target_field, regex = args.shift
+        opts = args.to_h
+        opts.reverse_merge!(use_keyword: true)
+        target_field = "#{target_field}.keyword" if opts.delete(:use_keyword)
+        opts.merge!(case_insensitive: true) if regex.casefold?
+        self.regexp_values += [[Hash[target_field, regex.source], opts]]
+        self
+      end
 
 
 

--- a/lib/stretchy/relations/query_methods.rb
+++ b/lib/stretchy/relations/query_methods.rb
@@ -187,7 +187,6 @@ module Stretchy
       # @return [ActiveRecord::Relation, WhereChain] a new relation, which reflects the conditions, or a WhereChain if opts is :chain
       # @see #must
       def where(opts = :chain, *rest)
-          puts "opts: #{opts} rest: #{rest}"
         if opts == :chain
           WhereChain.new(spawn)
         elsif opts.blank?

--- a/lib/stretchy/relations/query_methods.rb
+++ b/lib/stretchy/relations/query_methods.rb
@@ -187,27 +187,34 @@ module Stretchy
       # @return [ActiveRecord::Relation, WhereChain] a new relation, which reflects the conditions, or a WhereChain if opts is :chain
       # @see #must
       def where(opts = :chain, *rest)
+          puts "opts: #{opts} rest: #{rest}"
         if opts == :chain
           WhereChain.new(spawn)
         elsif opts.blank?
           self
         else
-          rest.each do |key, value|
+          opts.each do |key, value|
             case value
             when Range
               between(value, key)
             when Hash
               filter_query(:range, key => value) if value.keys.any? { |k| [:gte, :lte, :gt, :lt].include?(k) }
             when Regexp
-              regexp(key, value)
+              regexp(Hash[key, value])
             when Array
-              terms(key, value)
+              # handle ID queries
+              # if [:id, :_id].include?(key)
+
+              # else
+                spawn.where!(opts, *rest)
+              # end
             else
-              term(key, value)
+              spawn.where!(opts, *rest)
             end
           end
 
-          spawn.where!(opts, *rest)
+          self
+
         end
       end
 

--- a/lib/stretchy/shared_scopes.rb
+++ b/lib/stretchy/shared_scopes.rb
@@ -4,7 +4,7 @@ module Stretchy
 
         included do
 
-            scope :between, lambda { |range| filter(:range, "date" => {gte: range.begin, lte: range.end}) }
+            scope :between, ->(range, range_field = "created_at") { filter_query(:range, range_field => {gte: range.begin, lte: range.end}) }
             scope :using_time_based_indices, lambda { |range| search_options(index: time_based_indices(range)) }
 
         end

--- a/spec/stretchy/aggregations_spec.rb
+++ b/spec/stretchy/aggregations_spec.rb
@@ -294,6 +294,11 @@ describe "Aggregations" do
                         query_builder = described_class.size(0).aggregation(:time, date_histogram: { field: :created_at, interval: 'month' }).to_elastic
                         expect(query_builder[:aggregations][:time][:date_histogram][:field].to_s).to eq('created_at')
                     end
+
+                    it 'assumes keyword field in nested hashes' do
+                        query_builder = described_class.size(0).terms(:positions, field: 'position.name').to_elastic 
+                        expect(query_builder[:aggregations][:positions][:terms][:field].to_s).to eq('position.name.keyword')
+                    end
                 end
             end
 

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -115,7 +115,7 @@ describe "QueryMethods" do
                 
                   context 'when using regex' do
                     it 'handles regex' do
-                      expect(described_class.where(color: /gr(a|e)y/).to_elastic).to eq({regexp: {name: 'br.*n'}})
+                      expect(described_class.where(color: /gr(a|e)y/).to_elastic).to eq({query: {regexp: {'color.keyword': { value: 'gr(a|e)y' }}}}.with_indifferent_access)
                     end
                   end
                 

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -66,6 +66,27 @@ describe "QueryMethods" do
                     expect(described_class.order(age: :asc).count).to eq(19)
                 end
             end
+            context '.regexp' do
+                it 'adds a regexp query' do
+                    expect(described_class.regexp(name: /br.*n/).to_elastic).to eq({query: {regexp: {'name.keyword': { value: 'br.*n'}}}}.with_indifferent_access)
+                end
+
+                it 'adds a regexp query with flags' do
+                    expect(described_class.regexp(name: /br.*n/, flags: "ALL").to_elastic).to eq({query: {regexp: {'name.keyword': { value: 'br.*n', flags: "ALL"}}}}.with_indifferent_access)
+                end
+
+                it 'respects .where' do
+                    expect(described_class.where(name: "David Brown").regexp('position.name': /br.*n/).to_elastic).to eq({query: {bool: {must: {term: {'name.keyword': "David Brown"}}},regexp: {'position.name.keyword': { value: 'br.*n'}}}}.with_indifferent_access)
+                end
+
+                it 'handles case insensitive regex' do
+                    expect(described_class.regexp(name: /br.*n/i).to_elastic).to eq({query: {regexp: {'name.keyword': { value: 'br.*n', case_insensitive: true}}}}.with_indifferent_access)
+                end
+
+                it 'uses keyword when supplied' do
+                    expect(described_class.regexp(name: /br.*n/, use_keyword: true).to_elastic).to eq({query: {regexp: {'name.keyword': { value: 'br.*n'}}}}.with_indifferent_access)
+                end
+            end
 
             context '.where' do
                 let(:subject) { 
@@ -77,6 +98,39 @@ describe "QueryMethods" do
                     expect(described_class.where(age: 25).map(&:id)).to include(r.id)
                     r.delete
                 end
+
+                context 'when using ranges' do
+                    it 'handles date ranges' do
+                      expect(described_class.where(date: 2.days.ago...1.day.ago).to_elastic).to eq({range: {date: {gte: 2.days.ago, lt: 1.day.ago}}})
+                    end
+                
+                    it 'handles integer ranges' do
+                      expect(described_class.where(age: 18..30).to_elastic).to eq({range: {age: {gte: 18, lte: 30}}})
+                    end
+                
+                    it 'handles explicit range values' do
+                      expect(described_class.where(price: {gte: 100}).to_elastic).to eq({range: {price: {gte: 100}}})
+                    end
+                  end
+                
+                  context 'when using regex' do
+                    it 'handles regex' do
+                      expect(described_class.where(color: /gr(a|e)y/).to_elastic).to eq({regexp: {name: 'br.*n'}})
+                    end
+                  end
+                
+                  context 'when using terms' do
+                    it 'handles terms' do
+                      expect(described_class.where(name: ['Candy', 'Lilly']).to_elastic).to eq({terms: {name: ['Candy', 'Lilly']}})
+                    end
+                  end
+                
+                  context 'when using ids' do
+                    it 'handles ids' do
+                      expect(Model.where(id: [12, 80, 32]).to_elastic).to eq({ids: {values: [12, 80, 32]}})
+                    end
+                  end
+
             end
 
             context '.must_not' do

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -101,15 +101,17 @@ describe "QueryMethods" do
 
                 context 'when using ranges' do
                     it 'handles date ranges' do
-                      expect(described_class.where(date: 2.days.ago...1.day.ago).to_elastic).to eq({range: {date: {gte: 2.days.ago, lt: 1.day.ago}}})
+                      begin_date = 2.days.ago.beginning_of_day.utc
+                        end_date = 1.day.ago.end_of_day.utc
+                      expect(described_class.where(date: begin_date...end_date).to_elastic[:query][:bool]).to eq({filter: [{range: {date: {gte: begin_date, lte: end_date}}}]}.with_indifferent_access)
                     end
                 
                     it 'handles integer ranges' do
-                      expect(described_class.where(age: 18..30).to_elastic).to eq({range: {age: {gte: 18, lte: 30}}})
+                      expect(described_class.where(age: 18..30).to_elastic[:query][:bool]).to eq({filter: [{range: {age: {gte: 18, lte: 30}}}]}.with_indifferent_access)
                     end
                 
                     it 'handles explicit range values' do
-                      expect(described_class.where(price: {gte: 100}).to_elastic).to eq({range: {price: {gte: 100}}})
+                      expect(described_class.where(price: {gte: 100}).to_elastic).to eq({query: {bool: {filter:[ {range: {price: {gte: 100}}}]}}}.with_indifferent_access)
                     end
                   end
                 
@@ -121,12 +123,12 @@ describe "QueryMethods" do
                 
                   context 'when using terms' do
                     it 'handles terms' do
-                      expect(described_class.where(name: ['Candy', 'Lilly']).to_elastic).to eq({terms: {name: ['Candy', 'Lilly']}})
+                      expect(described_class.where(name: ['Candy', 'Lilly']).to_elastic).to eq({query: {bool:{must: {terms: {'name.keyword': ['Candy', 'Lilly']}}}}}.with_indifferent_access)
                     end
                   end
                 
                   context 'when using ids' do
-                    it 'handles ids' do
+                    xit 'handles ids' do
                       expect(Model.where(id: [12, 80, 32]).to_elastic).to eq({ids: {values: [12, 80, 32]}})
                     end
                   end

--- a/spec/stretchy/relations/query_builder_spec.rb
+++ b/spec/stretchy/relations/query_builder_spec.rb
@@ -31,6 +31,7 @@ describe Stretchy::Relations::QueryBuilder do
       multi_terms = {where: [{status: 'active'}, {category: 'ruby'}]}
       expect(described_class.new(multi_terms, attribute_types).query).to eq(subject.send(:compact_where, multi_terms[:where]))
     end
+
   end
 
   describe '#build_query' do


### PR DESCRIPTION
Adds conveniences to `.where` that make it easier to get results quickly. 

#### Ranges
```ruby
Model.where(date: 2.days.ago...1.day.ago)

Model.where(age: 18..30)
```

```ruby
Model.where(price: {gte: 100})
```

#### Regex

```ruby
Model.where(name: /br.*n/)
```

#### Terms

```ruby
Model.where(name: ['Candy', 'Lilly'])
```