### PR TITLE
Add attribute accessor for `.pluck`

### DIFF
--- a/lib/stretchy/common.rb
+++ b/lib/stretchy/common.rb
@@ -6,6 +6,9 @@ module Stretchy
             "#<#{self.class.name} #{attributes.map { |k,v| "#{k}: #{v.blank? ? 'nil' : v}" }.join(', ')}>"
         end
 
+        def [](attribute)
+            self.send(attribute)
+        end
 
         class_methods do
 

--- a/spec/stretchy/record_spec.rb
+++ b/spec/stretchy/record_spec.rb
@@ -73,7 +73,16 @@ describe Stretchy::Record do
             expect(described_class.default_size).to eq(100)
           end
 
+        end
+      end
 
+      context 'attributes' do
+
+        it 'accesses attributes' do
+          expect(described_class.new(title: "hello")[:title]).to eq("hello")
+        end
+        it 'plucks' do
+          expect(described_class.all.pluck(:title)).to be_a(Array)
         end
       end
 


### PR DESCRIPTION
This pull request adds an attribute accessor for `.pluck` in the `Stretchy::Record` class. It allows for accessing attributes using the `[]` method. Additionally, it includes a test case for plucking attributes.

Fixes #57