### PR TITLE
Fix highlighting and add support for storing and retrieving highlights

### DIFF
--- a/lib/stretchy/common.rb
+++ b/lib/stretchy/common.rb
@@ -10,6 +10,10 @@ module Stretchy
             self.send(attribute)
         end
 
+        def highlights_for(attribute)
+            highlights[attribute.to_s]
+        end
+
         class_methods do
 
             # Set the default sort key to be used in sort operations

--- a/lib/stretchy/model/serialization.rb
+++ b/lib/stretchy/model/serialization.rb
@@ -9,6 +9,7 @@ module Stretchy
 
             def deserialize(document)
                 attribs = ActiveSupport::HashWithIndifferentAccess.new(document['_source']).deep_symbolize_keys
+                attribs[:_highlights] = document["highlight"] if document["highlight"]
                 _id = __get_id_from_document(document)
                 attribs[:id] = _id if _id
                 klass.new attribs

--- a/lib/stretchy/record.rb
+++ b/lib/stretchy/record.rb
@@ -45,6 +45,13 @@ module Stretchy
                 # overriden by #size
                 default_size 10000
 
+                attr_accessor :highlights
+
+                def initialize(attributes = {})
+                    @highlights = attributes.delete(:_highlights) 
+                    super(attributes)
+                end
+
             end
 
             def initialize(attributes = {})

--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -174,7 +174,13 @@ module Stretchy
         structure.highlight do
           structure.fields do
             highlights.each do |highlight|
-              structure.set! highlight, extract_highlighter(highlight)
+              if highlight.is_a?(String) || highlight.is_a?(Symbol)
+                structure.set! highlight, {}
+              elsif highlight.is_a?(Hash)
+                highlight.each_pair do |k,v|
+                  structure.set! k, v
+                end
+              end
             end
           end
         end

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -278,9 +278,25 @@ describe "QueryMethods" do
 
             context 'highlight' do
                 it 'returns highlighted fields' do
-                    result = described_class.highlight(:body)
+                    result = described_class.highlight(body: {})
                     expected = {:highlight=>{:fields=>{body: {}}}}
                     expect(result.to_elastic).to eq(expected.with_indifferent_access)
+                end
+
+                it 'stores highlights' do
+                    result = described_class.query_string("name: Soph*").highlight(name: {pre_tags: "__", post_tags: "__"}).first
+                    expect(result.highlights).to eq({"name"=>["__Sophia__ Anderson"]})
+                end
+
+                it 'allows single symbol argument' do
+                    result = described_class.highlight(:body) 
+                    expected = {:highlight=>{:fields=>{body: {}}}}
+                    expect(result.to_elastic).to eq(expected.with_indifferent_access) 
+                end
+
+                it 'highlights_for ' do
+                    result = described_class.query_string("name: Soph*").highlight(name: {pre_tags: "__", post_tags: "__"}).first
+                    expect(result.highlights_for(:name)).to eq(["__Sophia__ Anderson"])
                 end
             end
 


### PR DESCRIPTION
This pull request fixes the issue with highlighting in the code and adds support for retrieving highlights. 

```ruby
CrashEvent.query_string("summary: propeller AND flight")
     .highlight(summary: {pre_tags: "__", post_tags: "__", fragment_size: 20})
     .first
     .highlights
```

All highlights are stored in `.highlights`
```ruby
{"summary"=>[
    "While on a __flight__ originating",
    "inaugural westbound __flight__",
    "to feather the No. 2 __propeller__"
  ]
} 
```

Access highlights for an attribute with `.highlights_for(:attribute_name)`
 ```ruby
CrashEvent.query_string("summary: propeller AND flight")
       .highlight(summary: {pre_tags: "__", post_tags: "__", fragment_size: 20})
       .first
       .highlights_for(:attribute_name)
```
>
> "While on a __flight__ originating ... inaugural westbound __flight__ ... to feather the No. 2 __propeller__"
>