### PR TITLE
Add instrumentation

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -14,6 +14,9 @@ print "\t    " * 7
 print Rainbow(" v#{Stretchy::VERSION}").white.faint
 print "\n\n"
 
+
+Stretchy.instrument!
+
 ActiveSupport::Notifications.subscribe 'search.stretchy' do |name, start, finish, id, payload|
    message = [
       Rainbow("  #{payload[:klass]}").bright, 

--- a/lib/rails/instrumentation/railtie.rb
+++ b/lib/rails/instrumentation/railtie.rb
@@ -4,6 +4,8 @@ module Stretchy
     class Railtie < ::Rails::Railtie
 
       require 'rails/instrumentation/publishers'
+      Stretchy.instrument!
+
       ActiveSupport::Notifications.subscribe 'search.stretchy' do |name, start, finish, id, payload|
         message = [
            Rainbow("  #{payload[:klass]}").bright, 

--- a/lib/stretchy.rb
+++ b/lib/stretchy.rb
@@ -30,6 +30,10 @@ module Stretchy
     Stretchy::Attributes.register!
   end
 
+  def self.instrument!
+    Stretchy::Delegation::GatewayDelegation.send(:include, Rails::Instrumentation::Publishers::Record)
+  end
+
   module Errors
     class QueryOptionMissing < StandardError; end
   end

--- a/lib/stretchy/delegation/gateway_delegation.rb
+++ b/lib/stretchy/delegation/gateway_delegation.rb
@@ -18,8 +18,6 @@ module Stretchy
                 :count,
         to: :gateway
 
-      include Rails::Instrumentation::Publishers::Record
-
       def index_name(name=nil, &block)
           if name || block_given?
             return (@index_name = name || block)


### PR DESCRIPTION
This pull request adds instrumentation to the codebase by injecting publishers and `search_with_instrumentation` into `GatewayDelegation` instead of including the module manually. This change improves the code's maintainability and readability. Fixes #13.