### PR TITLE
Version bump to v0.6.0

### DIFF
--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
This pull request updates the version of the Stretchy library to v0.6.0.