### PR TITLE
Fix issues with .where method and ranges

### DIFF
--- a/lib/stretchy/shared_scopes.rb
+++ b/lib/stretchy/shared_scopes.rb
@@ -4,7 +4,12 @@ module Stretchy
 
         included do
 
-            scope :between, ->(range, range_field = "created_at") { filter_query(:range, range_field => {gte: range.begin, lte: range.end}) }
+            scope :between, ->(range, range_field = "created_at") do
+                range_options = {gte: range.begin}
+                upper_bound = range.exclude_end? ? :lt : :lte
+                range_options[upper_bound] = range.end
+                filter_query(:range, range_field => range_options)
+            end
             scope :using_time_based_indices, lambda { |range| search_options(index: time_based_indices(range)) }
 
         end

--- a/spec/stretchy/querying_spec.rb
+++ b/spec/stretchy/querying_spec.rb
@@ -99,10 +99,16 @@ describe "QueryMethods" do
                 end
 
                 context 'when using ranges' do
-                    it 'handles date ranges' do
+                    it 'gte and lte with .. ranges' do
                       begin_date = 2.days.ago.beginning_of_day.utc
                         end_date = 1.day.ago.end_of_day.utc
-                      expect(described_class.where(date: begin_date...end_date).to_elastic[:query][:bool]).to eq({filter: [{range: {date: {gte: begin_date, lte: end_date}}}]}.with_indifferent_access)
+                      expect(described_class.where(date: begin_date..end_date).to_elastic[:query][:bool]).to eq({filter: [{range: {date: {gte: begin_date, lte: end_date}}}]}.with_indifferent_access)
+                    end
+
+                    it 'gte and lt with ... ranges' do
+                        begin_date = 2.days.ago.beginning_of_day.utc
+                        end_date = 1.day.ago.end_of_day.utc
+                      expect(described_class.where(date: begin_date...end_date).to_elastic[:query][:bool]).to eq({filter: [{range: {date: {gte: begin_date, lt: end_date}}}]}.with_indifferent_access)
                     end
                 
                     it 'handles integer ranges' do


### PR DESCRIPTION
Was working as expected. `range`  filter works for date ranges and if attribute is a `keyword` it functions as expected. 

Inclusive range forms now adjust the upper bound of the range query:

```ruby
begin_date = 2.days.ago.beginning_of_day.utc
end_date = 1.day.ago.end_of_day.utc
CrashEvent.where(occurred_on: begin_date..end_date)
# => {filter: [{range: {date: {gte: begin_date, lte: end_date}}}]}

CrashEvent.where(occurred_on: begin_date...end_date)
# => {filter: [{range: {date: {gte: begin_date, lt: end_date}}}]}
```

Fixes #91