### PR TITLE
Fix #105 Add `IndexSetting`

### DIFF
--- a/lib/stretchy/index_setting.rb
+++ b/lib/stretchy/index_setting.rb
@@ -1,0 +1,94 @@
+# This class is used to define settings for an Elasticsearch index. 
+# It provides methods to define analyzers, filters, tokenizers, and normalizers.
+#
+# ## Usage
+# ```ruby
+# class MyIndexSetting < Stretchy::IndexSetting
+#   analyzer :default, 
+#            filter: [:lowercase, :asciifolding],
+#            tokenizer: :standard
+#
+#   filter :my_stemmer,
+#          type: :stemmer,
+#          name: :light_english
+#
+#   tokenizer :path_tokenizer, 
+#             type: :path_hierarchy,
+#             reverse: true
+#
+#   normalizer :my_normalizer, 
+#              type: :custom,
+#              filter: [:lowercase]
+# end
+# ```
+#
+# In this example, we define a custom index setting `MyIndexSetting` that includes a default analyzer, a custom filter, a custom tokenizer, and a custom normalizer.
+#
+# ## Methods
+# - `analyzer(name, options)`: Defines an analyzer with the given name and options.
+# - `filter(name, options)`: Defines a filter with the given name and options.
+# - `tokenizer(name, options)`: Defines a tokenizer with the given name and options.
+# - `normalizer(name, options)`: Defines a normalizer with the given name and options.
+#
+# Each of these methods takes a name as the first argument and a hash of options as the second argument. The options will depend on the specific type of analyzer, filter, tokenizer, or normalizer being defined.
+#
+# ### Accessing Defined Settings
+# You can access the settings defined in an `IndexSetting` subclass using the `analyzers`, `filters`, `tokenizers`, and `normalizers` methods. These methods return a hash of the defined settings for their respective type.
+#
+# ```ruby
+#  MyIndexSetting.analyzers
+#  # => { default: { filter: [:lowercase, :asciifolding], tokenizer: :standard } }
+# ```
+#
+# ```ruby
+#  MyIndexSetting.filters
+#  # => { my_stemmer: { type: :stemmer, name: :light_english } }
+# ```
+#
+# ```ruby
+#  MyIndexSetting.tokenizers
+#  # => { path_tokenizer: { type: :path_hierarchy, reverse: true } }
+# ```
+#
+# ```ruby
+#  MyIndexSetting.normalizers
+#  # => { my_normalizer: { type: :custom, filter: [:lowercase] } }
+# ```
+# ### Using the Settings
+# You can use the settings defined in an `IndexSetting` subclass to configure the settings for a `StretchyModel`.
+#
+# ```ruby
+# class MyModel < StretchyModel
+#  index_settings(MyIndexSetting.as_json)
+# end
+# ```
+#
+module Stretchy
+  class IndexSetting
+    class << self
+      METHODS = [:analyzer, :filter, :tokenizer, :normalizer]
+
+      def settings
+        @settings ||= {}
+      end
+
+      def as_json
+        {
+          self.name.demodulize.underscore.to_sym => settings
+        }
+      end
+
+      METHODS.each do |method|
+        define_method(method) do |*args|
+          settings[method] ||= {}
+          settings[method][args.shift] = Hash[*args] unless args.empty?
+        end
+
+        define_method("#{method}s") do
+          settings[method] || {}
+        end
+      end
+
+    end
+  end
+end

--- a/spec/stretchy/index_setting_spec.rb
+++ b/spec/stretchy/index_setting_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe Stretchy::IndexSetting do
+  describe 'class methods' do
+    it 'responds to analyzer' do
+      expect(described_class).to respond_to(:analyzer)
+    end
+
+    it 'responds to filter' do
+      expect(described_class).to respond_to(:filter)
+    end
+
+    it 'responds to tokenizer' do
+      expect(described_class).to respond_to(:tokenizer)
+    end
+
+    it 'responds to normalizer' do
+      expect(described_class).to respond_to(:normalizer)
+    end
+
+    let(:subject) do
+      Analysis = Class.new(Stretchy::IndexSetting) do
+        analyzer :default, filter: [:lowercase], tokenizer: :standard
+
+        analyzer :path_analyzer,
+          filter: [
+            :lowercase,
+            :asciifolding
+          ],
+          type: :custom,
+          tokenizer: :path_tokenizer
+
+        filter :lowercase, type: :lowercase
+
+        tokenizer :standard, type: :standard
+
+        normalizer :default, filter: [:lowercase], tokenizer: :standard
+      end
+    end
+    it 'returns settings as_json' do
+
+      expect(subject.as_json).to eq(
+        {
+          analysis: {
+            analyzer: {
+              default: { filter: [:lowercase], tokenizer: :standard },
+              path_analyzer: 
+                { filter: [:lowercase, :asciifolding], type: :custom, tokenizer: :path_tokenizer }
+            },
+            filter: {
+              lowercase: { type: :lowercase }
+            },
+            tokenizer: {
+              standard: { type: :standard }
+            },
+            normalizer: {
+              default: { filter: [:lowercase], tokenizer: :standard }
+            }
+          }
+        }
+      )
+
+    end
+
+    context 'collection' do
+      it 'returns the analyzers' do
+        described_class.analyzer(:default, filter: [:lowercase], tokenizer: :standard)
+        expect(described_class.analyzers).to eq({ default: { filter: [:lowercase], tokenizer: :standard } })
+      end
+
+      it 'returns the filters' do
+        described_class.filter(:lowercase, type: :lowercase)
+        expect(described_class.filters).to eq({ lowercase: { type: :lowercase } })
+      end
+
+      it 'returns the tokenizers' do
+        described_class.tokenizer(:standard, type: :standard)
+        expect(described_class.tokenizers).to eq({ standard: { type: :standard } })
+      end
+    
+      it 'returns the normalizers' do
+        described_class.normalizer(:default, filter: [:lowercase], tokenizer: :standard)
+        expect(described_class.normalizers).to eq({ default: { filter: [:lowercase], tokenizer: :standard } })
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request fixes issue #105 by adding the `IndexSetting` class. The `IndexSetting` class is used to define settings for an Elasticsearch index, including analyzers, filters, tokenizers, and normalizers. The class provides methods to define these settings and allows access to the defined settings. 

```ruby
class Analysis < Stretchy::IndexSetting

	filter :my_stemmer,
				name: :light_english,
				type: :stemmer

	filter :word_delimiter_graph_filter,
				type: :word_delimiter_graph,
				preserve_original: true

	filter :edge_ngram_filter, 
				type: :edge_ngram,
				min_gram: 2,
				max_gram: 40
	
	analyzer :default, 
					filter: [
						:lowercase,
						:my_stemmer
					],
					tokenizer: :standard

	analyzer :path_analyzer, 
					filter: [
						:lowercase,
						:asciifolding
					],
					type: :custom,
					tokenizer: :path_tokenizer

	analyzer :code_analyzer, 
					filter: [
						:word_delimiter_graph_filter,
						:flatten_graph,
						:lowercase,
						:asciifolding,
						:edge_ngram_filter
					],
					type: :custom,
					tokenizer: :whitespace
		
	
	analyzer :my_ngram_analyzer, 
					filter: [:lowercase],
					tokenizer: :my_ngram_tokenizer
	
	
	analyzer :whitespace_reverse, 
					tokenizer: :whitespace,
					filter: [:lowercase, :asciifolding, :reverse]
		
	
	tokenizer :my_ngram_tokenizer, 
					token_chars: [:letter,:digit],
					min_gram: 2,
					max_gram: 3
					type: :ngram

	tokenizer :path_tokenizer, 
					reverse: true,
					type: :path_hierarchy
		
	
	normalizer :sha_normalizer, 
					filter: [:lowercase],
					type: :custom


end
```

```ruby
class RepoFile < StretchyModel
	attribute :type, :keyword
	attribute :OID, :keyword
	attribute :commit_sha, :string, fields: {slug: {type: 'keyword'}, bork: {type: 'keyword'}}
	attribute :content, :text, analyzer: :code_analyzer, index_options: :positions
	attribute :path, :string
	attribute :file_name, :string, analyzer: :code_analyzer
	attribute :language, :keyword, index: false
	attribute :repo_id, :keyword


	index_settings(Analysis.settings)

end
```