### PR TITLE
Add knn_vector type

### DIFF
--- a/lib/stretchy/attributes.rb
+++ b/lib/stretchy/attributes.rb
@@ -66,6 +66,7 @@ module Stretchy
       ActiveModel::Type.register(:ip, Stretchy::Attributes::Type::IP)
       ActiveModel::Type.register(:join, Stretchy::Attributes::Type::Join)
       ActiveModel::Type.register(:keyword, Stretchy::Attributes::Type::Keyword)
+      ActiveModel::Type.register(:knn_vector, Stretchy::Attributes::Type::KnnVector)
       ActiveModel::Type.register(:match_only_text, Stretchy::Attributes::Type::MatchOnlyText)
       ActiveModel::Type.register(:nested, Stretchy::Attributes::Type::Nested)
       ActiveModel::Type.register(:percolator, Stretchy::Attributes::Type::Percolator)

--- a/lib/stretchy/attributes/type/knn_vector.rb
+++ b/lib/stretchy/attributes/type/knn_vector.rb
@@ -1,0 +1,47 @@
+module Stretchy::Attributes::Type
+  # The KnnVector attribute type.
+  #
+  # This class is used to define a `knn_vector` attribute for a model. 
+  # It provides support for the Elasticsearch `knn_vector` data type, 
+  # which is a type of data type that can hold vectors of float values.
+  #
+  # ### Parameters
+  #
+  # The `knn_vector` data type supports the following options:
+  # - `dimension`: The number of dimensions in the vector.
+  # - `method`: The method used for nearest neighbor search. This is a hash that can include the following keys:
+  #   - `name`: The name of the method.
+  #   - `space_type`: The type of space used for the method.
+  #   - `engine`: The engine used for the method.
+  #   - `parameters`: Any additional parameters for the method.
+  #
+  # ---
+  #
+  # ### Examples
+  #
+  #
+  # #### Define a `knn_vector` attribute
+  #
+  # ```ruby
+  #   class MyModel < StretchyModel
+  #     attribute :my_vector, :knn_vector
+  #   end
+  # ```
+  #
+  # #### Define a `knn_vector` attribute with options
+  #
+  # ```ruby
+  #   class MyModel < StretchyModel
+  #     attribute :my_vector, :knn_vector, dimension: 3, method: { name: "hnsw", space_type: "cosinesimil", engine: "nmslib", parameters: { ef_construction: 200 } }
+  #   end
+  # ```
+  #
+  class KnnVector < Stretchy::Attributes::Type::Base
+      OPTIONS = [:dimension, :method]
+
+      def type
+        :knn_vector
+      end
+
+  end
+end

--- a/spec/stretchy/attributes/type/knn_vector_spec.rb
+++ b/spec/stretchy/attributes/type/knn_vector_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe "KnnVector" do
+
+  let(:model_class) {
+    class KnnModel < StretchyModel
+      attribute :vector, :knn_vector
+    end
+    KnnModel
+  }
+
+  it 'has a type' do
+    vector_attribute = model_class.attribute_types["vector"]
+    expect(vector_attribute.type).to eq(:knn_vector)
+  end
+
+  it 'has mappings' do
+    vector_attribute = model_class.attribute_types["vector"]
+    mappings = vector_attribute.mappings("vector")
+    expect(mappings).to eq(
+      {
+        "vector": {
+          type: :knn_vector
+        }
+      }.as_json
+    )
+  end
+
+  context 'with options' do
+    it 'has mappings' do
+      model_class.attribute :embeddings, :knn_vector, dimension: 3, method: 'cosine'
+      vector_attribute = model_class.attribute_types["embeddings"]
+      mappings = vector_attribute.mappings("embeddings")
+      expect(mappings).to eq(
+        {
+          "embeddings": {
+            type: :knn_vector,
+            dimension: 3,
+            method: 'cosine'
+          }
+        }.as_json
+      )
+    end
+  end
+
+
+
+end


### PR DESCRIPTION
This pull request adds a new attribute type called `knn_vector` to the Stretchy gem. The `knn_vector` attribute type is used to define a vector of float values in Opensearch. It supports options such as dimension and method for nearest neighbor search. This PR includes the necessary code changes and tests for the new attribute type.