### PR TITLE
Support match in where, must, should, must_not

### DIFF
--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -15,6 +15,64 @@ You can pass one or more key-value pairs to `.where` to search for documents whe
 Model.where(color: 'blue', :title: "Candy")
 ```
 
+>[!INFO|label:Default Behavior|style:flat]
+> The default behavior is to create a term query for each argument against keyword fields. 
+
+```ruby
+Model.must(file_name: 'rb', content: '.where')
+```
+
+```ruby
+{
+  "query" => {
+    "bool" => {
+      "must" => [
+        {
+          "term" => {
+            "file_name.keyword" => "rb"
+          }
+        },
+        {
+          "term" => {
+            "content.keyword" => ".where"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+For `match` behavior the query can be modified like so:
+
+```ruby
+Model.must(match: {file_name: '*.rb', content: '.where'})
+#or Model.where(match: {file_name: '*.rb', content: '.where'})
+```
+
+```ruby
+{
+  "query" => {
+    "bool" => {
+      "must" => [
+        {
+          "match" => {
+            "file_name" => "*.rb"
+          }
+        },
+        {
+          "match" => {
+            "content" => ".where"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+
+
 ##### Ranges
 You can use ranges to search for documents where a field's value falls within a certain range. For example,
 ```ruby

--- a/lib/stretchy/relations/query_builder.rb
+++ b/lib/stretchy/relations/query_builder.rb
@@ -318,10 +318,16 @@ module Stretchy
         q.each do |arg|
           case arg
           when Hash
-            arg = keyword_transformer.transform(arg)
+            arg = keyword_transformer.transform(arg, :match)
             arg.each_pair do |k,v| 
-              # If v is an array, we build a terms query otherwise a term query
-              _must << (v.is_a?(Array) ? {terms: Hash[k,v]} : {term: Hash[k,v]}) 
+              if k == :match
+                v.each do |field, value|
+                  _must << (field.is_a?(Hash) ? { k => field} : { k => {field => value}})
+                end
+              else
+                # If v is an array, we build a terms query otherwise a term query
+                _must << (v.is_a?(Array) ? {terms: Hash[k,v]} : {term: Hash[k,v]}) 
+              end
             end
           when String
             _must << {term: Hash[[arg.split(/:/).collect(&:strip)]]}

--- a/lib/stretchy/relations/query_methods/where.rb
+++ b/lib/stretchy/relations/query_methods/where.rb
@@ -69,7 +69,9 @@ module Stretchy
                 range_options[upper_bound] = range.end
                 filter_query(:range, key => range_options)
               when Hash
-                opts.delete(key)
+                hash = opts.delete(key)
+                spawn.where!(key => hash) if [:match, :match_phrase, :match_phrase_prefix].include?(key)
+
                 filter_query(:range, key => value) if value.keys.any? { |k| [:gte, :lte, :gt, :lt].include?(k) }
               when ::Regexp
                 opts.delete(key)

--- a/spec/stretchy/relations/query_methods/where_spec.rb
+++ b/spec/stretchy/relations/query_methods/where_spec.rb
@@ -30,6 +30,13 @@ describe Stretchy::Relations::QueryMethods::Where do
       end
     end
 
+    context 'match' do
+      it 'handles match' do
+        relation.where(match: {title: 'Fun times'})
+        expect(relation_values).to eq([match: {title: 'Fun times'}])
+      end
+    end
+
 
     context 'when using ranges' do
         let(:relation_filter_values) { relation.values[:filter_query] }
@@ -210,6 +217,55 @@ describe Stretchy::Relations::QueryMethods::Where do
               },
               {
                 term: {
+                  color: 'blue'
+                }
+              }
+            ]
+          )
+        end
+      end
+
+      context 'match' do
+        it 'is a match query' do
+          values[:where] = [{match: {name: 'Fun times'}}]
+          expect(clause).to eq(
+            {
+              match: {
+                name: 'Fun times'
+              }
+            }
+          )
+        end
+
+        it 'multiple fields per match' do
+          values[:where] = [{:match=>{:file_name=>"*.rb", :content=>".where"}}]
+          expect(clause).to eq(
+            [
+              {
+                match: {
+                  file_name: "*.rb",
+                },
+              },
+              {
+                match: {
+                  content: ".where"
+                }
+              }
+            ]
+          )
+        end
+
+        it 'is a match query for each distinct field' do
+          values[:where] = [{match: {name: 'Fun times'}}, {match: {color: 'blue'}}]
+          expect(clause).to eq(
+            [
+              {
+                match: {
+                  name: 'Fun times'
+                }
+              },
+              {
+                match: {
                   color: 'blue'
                 }
               }


### PR DESCRIPTION
This pull request adds support for the `match` query in the `where`, `must`, `should`, and `must_not` methods. It allows users to perform match queries on specific fields in their Elasticsearch queries.

```ruby
Model.must(match: {color: "blu"})

Model.should(match: {color: "blu", size: "L"})
```