### PR TITLE
Version bump to 0.6.6

### DIFF
--- a/lib/stretchy/version.rb
+++ b/lib/stretchy/version.rb
@@ -1,3 +1,3 @@
 module Stretchy
-  VERSION = '0.6.5'
+  VERSION = '0.6.6'
 end


### PR DESCRIPTION
This pull request updates the version of the Stretchy library to 0.6.6.