### PR TITLE
Fix issues with MachineLearning::Model::Registry and add rake tasks to manage indices, pipelines, and models

### DIFF
--- a/lib/stretchy.rb
+++ b/lib/stretchy.rb
@@ -36,6 +36,10 @@ module Stretchy
     Stretchy::Delegation::GatewayDelegation.send(:include, Rails::Instrumentation::Publishers::Record)
   end
 
+  def self.env
+    ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
+  end
+
   module Errors
     class QueryOptionMissing < StandardError; end
   end

--- a/lib/stretchy.rb
+++ b/lib/stretchy.rb
@@ -10,6 +10,7 @@ require 'active_support/all'
 
 require_relative "stretchy/version"
 require_relative "stretchy/rails/instrumentation/railtie" if defined?(Rails)
+require_relative "stretchy/rails/railtie" if defined?(Rails)
 require_relative 'elasticsearch/api/namespace/machine_learning/model'
 
 module Stretchy

--- a/lib/stretchy/machine_learning/errors.rb
+++ b/lib/stretchy/machine_learning/errors.rb
@@ -1,0 +1,5 @@
+module Stretchy::MachineLearning::Errors
+  class ModelNotDeployedError < StandardError; end
+  class ModelNotRegisteredError < StandardError; end
+  class ModelMissingError < StandardError; end
+end

--- a/lib/stretchy/machine_learning/model.rb
+++ b/lib/stretchy/machine_learning/model.rb
@@ -31,11 +31,152 @@ module Stretchy
       end
 
       class << self
-        attr_accessor :model, :group_id 
 
-        def model(model_name = nil, **args)
-          return @model if model_name.nil?
-          @model = self.new(**{model: model_name}.merge(args))
+        # delegate :find, :status, :deployed?, :registered?, :task_id, :deploy_id, :model_id, :register, :deploy, :undeploy, :delete, to: :model
+
+        METHODS = [
+                    :model,
+                    :group_id, 
+                    :version, 
+                    :description, 
+                    :model_format, 
+                    :enabled, 
+                    :connector_id, 
+                    :connector, 
+                    :function_name, 
+                    :model_config, 
+                    :model_content_hash_value, 
+                    :url  
+                  ]
+
+        def settings
+          @settings ||= {}
+        end
+
+        METHODS.each do |method|
+          define_method(method) do |args = nil|
+            return settings[method] unless args.present?
+            settings[method] = args
+          end
+        end
+
+        def model(model = nil)
+          return settings[:model] unless model
+          settings[:model] = model_lookup(model)
+        end
+
+        def model_id
+          @model_id || registry.model_id
+        end
+
+        def task_id
+          @task_id || registry.register_task_id
+        end
+
+        def deploy_id
+          @deploy_id || registry.deploy_task_id
+        end
+
+
+        def registry
+          @registry ||= Stretchy::MachineLearning::Registry.register(class_name: self.name)
+        end
+
+        def register
+          begin
+  
+            response = client.register(body: self.to_hash, deploy: true)
+  
+            @task_id = response['task_id']
+  
+            self.registry.update(register_task_id: @task_id)
+  
+            yield self if block_given? 
+  
+            registered?
+            self.registry.update(model_id: @model_id) 
+            @model_id
+          rescue => e
+            Stretchy.logger.error "Error registering model: #{e.message}"
+            false
+          end
+          true
+        end
+
+        def registered?
+          return false unless task_id
+          response = status
+          @model_id = response['model_id'] if response['model_id']
+          response['state'] == 'COMPLETED' && @model_id.present?
+        end
+  
+        def status
+          client.get_status(task_id: self.task_id)
+        end
+
+
+        def deploy
+          @deployed = nil
+
+          @deploy_id = client.deploy(id: self.model_id)['task_id']
+          self.registry.update(deploy_task_id: @deploy_id)
+          yield self if block_given? 
+          @deploy_id
+        end
+  
+        def undeploy
+          @deployed = nil
+          response = client.undeploy(id: self.model_id)
+          self.registry.update(deploy_task_id: nil)
+          yield self if block_given? 
+          response
+        end
+  
+        def deployed?
+          return @deployed if @deployed
+          response = client.get_model(id: self.model_id)
+          # raise "Model not deployed" if response['model_state'] == 'FAILED'
+          @deployed = response['model_state'] == 'DEPLOYED'
+        end
+  
+        def delete
+          self.registry.delete
+          client.delete_model(id: self.model_id)
+        end
+
+        def find 
+          begin
+            client.get_model(id: self.model_id)
+          rescue "#{Stretchy.search_backend_const}::Transport::Transport::Errors::InternalServerError".constantize => e
+            raise Stretchy::MachineLearning::Errors::ModelMissingError
+          end
+        end
+  
+        def to_hash
+          {
+            name: self.model,
+            model_group_id: self.group_id,
+            version: self.version,
+            description: self.description,
+            model_format: self.model_format,
+            is_enabled: self.enabled?,
+            uid: self.class.name.underscore
+          }.compact
+        end
+  
+        def enabled?
+          self.enabled
+        end
+  
+        def wait_until_complete(max_attempts: 20, sleep_time: 4)
+          attempts = 0
+          loop do
+            result = yield
+            break if result
+            attempts += 1
+            break if attempts >= max_attempts
+            sleep(sleep_time)
+          end
         end
 
         def all
@@ -80,116 +221,6 @@ module Stretchy
           end.to_h
 
           @flattened_models[model.to_sym] || model.to_s
-        end
-      end
-
-      attr_accessor :model,
-                    :group_id, 
-                    :version, 
-                    :description, 
-                    :model_format, 
-                    :enabled, 
-                    :connector_id, 
-                    :connector, 
-                    :function_name, 
-                    :model_config, 
-                    :model_content_hash_value, 
-                    :url
-
-      attr_reader :task_id, :model_id, :deploy_id
-
-      def initialize(args = {})
-        model_name = args.delete(:model)
-        args.each do |k,v|
-          self.send("#{k}=", v)
-        end
-        @model = self.class.model_lookup model_name
-      end
-
-      def register
-        begin
-          response = client.register(body: self.to_hash, deploy: true)
-
-          @task_id = response['task_id']
-
-          yield self if block_given? 
-
-          @model_id
-        rescue => e
-          Stretchy.logger.error "Error registering model: #{e.message}"
-          false
-        end
-        true
-      end
-
-      def registered?
-        return false unless @task_id
-        response = status
-        @model_id = response['model_id'] if response['model_id']
-        response['state'] == 'COMPLETED' && @model_id.present?
-      end
-
-      def status
-        client.get_status(task_id: self.task_id)
-      end
-
-      def deploy
-        @deployed = nil
-        @deploy_id = client.deploy(id: self.model_id)['task_id']
-        yield self if block_given? 
-        @deploy_id
-      end
-
-      def undeploy
-        @deployed = nil
-        response = client.undeploy(id: self.model_id)
-        yield self if block_given? 
-        response
-      end
-
-      def deployed?
-        return @deployed if @deployed
-        response = client.get_model(id: self.model_id)
-        # raise "Model not deployed" if response['model_state'] == 'FAILED'
-        @deployed = response['model_state'] == 'DEPLOYED'
-      end
-
-      def delete
-        client.delete_model(id: self.model_id)
-      end
-
-      def client
-        @@client
-      end
-
-      def find 
-        client.get_model(id: self.model_id)
-      end
-
-      def to_hash
-        {
-          name: self.model,
-          model_group_id: self.group_id,
-          version: self.version,
-          description: self.description,
-          model_format: self.model_format,
-          is_enabled: self.enabled?,
-          uid: self.class.name.underscore
-        }.compact
-      end
-
-      def enabled?
-        self.enabled
-      end
-
-      def wait_until_complete(max_attempts: 20, sleep_time: 4)
-        attempts = 0
-        loop do
-          result = yield
-          break if result
-          attempts += 1
-          break if attempts >= max_attempts
-          sleep(sleep_time)
         end
       end
 

--- a/lib/stretchy/machine_learning/model.rb
+++ b/lib/stretchy/machine_learning/model.rb
@@ -33,6 +33,11 @@ module Stretchy
       class << self
         attr_accessor :model, :group_id 
 
+        def model(model_name = nil, **args)
+          return @model if model_name.nil?
+          @model = self.new(**{model: model_name}.merge(args))
+        end
+
         def all
           client.get_model
         end
@@ -118,6 +123,7 @@ module Stretchy
       end
 
       def registered?
+        return false unless @task_id
         response = status
         @model_id = response['model_id'] if response['model_id']
         response['state'] == 'COMPLETED' && @model_id.present?
@@ -167,7 +173,8 @@ module Stretchy
           version: self.version,
           description: self.description,
           model_format: self.model_format,
-          is_enabled: self.enabled?
+          is_enabled: self.enabled?,
+          uid: self.class.name.underscore
         }.compact
       end
 

--- a/lib/stretchy/machine_learning/registry.rb
+++ b/lib/stretchy/machine_learning/registry.rb
@@ -1,0 +1,18 @@
+module Stretchy::MachineLearning
+  class Registry < StretchyModel
+
+    index_name ".stretchy_ml_registry_#{Stretchy.env}"
+
+    attribute :model_id, :keyword
+    attribute :model_group_id, :keyword
+    attribute :deploy_task_id, :keyword
+    attribute :register_task_id, :keyword
+    attribute :class_name, :keyword
+
+    def self.register(**args) 
+      self.create_index! unless index_exists?
+      where(class_name: args[:class_name]).first || create(**args)
+    end
+
+  end
+end

--- a/lib/stretchy/pipelines/processor.rb
+++ b/lib/stretchy/pipelines/processor.rb
@@ -48,9 +48,11 @@ module Stretchy::Pipelines
       @type = type
       @description = opts[:description]
       @opts = opts
+      @model = opts.delete(:model)
     end
 
     def to_hash
+      @opts[:model_id] = @model.model_id if @model
       { type => @opts }
     end
   end

--- a/lib/stretchy/rails/railtie.rb
+++ b/lib/stretchy/rails/railtie.rb
@@ -1,0 +1,11 @@
+module Stretchy
+  module Rails
+    class Railtie < ::Rails::Railtie
+
+      rake_tasks do
+        load "#{__dir__}/tasks/stretchy.rake"
+      end
+
+    end
+  end
+end

--- a/lib/stretchy/rails/tasks/index/create.rake
+++ b/lib/stretchy/rails/tasks/index/create.rake
@@ -1,0 +1,23 @@
+namespace :stretchy do
+  namespace :index do
+    desc "Create the index"
+    task create: :environment do
+      klass = ENV['MODEL']
+      unless klass.nil?
+        klass = klass.constantize
+        # klass.create_index!
+      else
+        StretchyModel.descendants.each do |klass|
+          Rainbow("Creating index for #{klass}").bright
+
+          # response = klass.create_index!
+          if response['acknowledged']
+            Rainbow("[SUCCESS]").green
+          else
+            Rainbow("[FAILED]").red
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stretchy/rails/tasks/index/delete.rake
+++ b/lib/stretchy/rails/tasks/index/delete.rake
@@ -1,19 +1,19 @@
 namespace :stretchy do
   namespace :index do
-    desc "Create indices"
-    task create: :environment do
+    desc "Delete indices"
+    task delete: :environment do
       klass = ENV['MODEL']
       models = klass.nil? ? StretchyModel.descendants : [klass.constantize]
         models.each do |model|
           next if model.name == "Stretchy::MachineLearning::Registry"
-          spinner = TTY::Spinner.new("Creating index #{model} (#{model.index_name}) ".ljust(JUSTIFICATION) + ":spinner", format: :dots)
+          spinner = TTY::Spinner.new("Deleting index #{model} (#{model.index_name}) ".ljust(JUSTIFICATION) + ":spinner", format: :dots)
           spinner.auto_spin
-          if model.index_exists?
-            spinner.stop( Rainbow("[EXISTS]").orange)
+          unless model.index_exists?
+            spinner.stop( Rainbow("[MISSING]").white)
             next
           end
 
-          response = model.create_index!
+          response = model.delete_index!
           status = if response
             Rainbow("[SUCCESS]").green
           else

--- a/lib/stretchy/rails/tasks/index/status.rake
+++ b/lib/stretchy/rails/tasks/index/status.rake
@@ -3,20 +3,19 @@ namespace :stretchy do
     desc "Check the status of all indexes"
     task status: :environment do
       klass = ENV['MODEL']
-      unless klass.nil?
-        klass = klass.constantize
-      end
+
       Rails.application.eager_load!
+      models = klass.nil? ? StretchyModel.descendants : [klass.constantize]
 
       puts Rainbow("Indexes").color :gray
-      StretchyModel.descendants.each do |klass|
-        response = klass.index_exists?
+      models.each do |model|
+        response = model.index_exists?
         status = if response
           Rainbow("[CREATED]").green.bright
         else
-          Rainbow("[MISSING]").gray.bright
+          Rainbow("[MISSING]").white
         end
-        puts "#{klass.index_name}".ljust(60) + status
+        puts "#{model.index_name}".ljust(JUSTIFICATION) + status
       end
       puts "\n\n"
     end

--- a/lib/stretchy/rails/tasks/index/status.rake
+++ b/lib/stretchy/rails/tasks/index/status.rake
@@ -1,0 +1,24 @@
+namespace :stretchy do
+  namespace :index do
+    desc "Check the status of all indexes"
+    task status: :environment do
+      klass = ENV['MODEL']
+      unless klass.nil?
+        klass = klass.constantize
+      end
+      Rails.application.eager_load!
+
+      puts Rainbow("Indexes").color :gray
+      StretchyModel.descendants.each do |klass|
+        response = klass.index_exists?
+        status = if response
+          Rainbow("[CREATED]").green.bright
+        else
+          Rainbow("[MISSING]").gray.bright
+        end
+        puts "#{klass.index_name}".ljust(60) + status
+      end
+      puts "\n\n"
+    end
+  end
+end

--- a/lib/stretchy/rails/tasks/ml/delete.rake
+++ b/lib/stretchy/rails/tasks/ml/delete.rake
@@ -1,0 +1,25 @@
+namespace :stretchy do
+  namespace :ml do
+
+    desc "Delete the model ENV['MODEL']"
+    task delete: :environment do
+      klass = ENV['MODEL']
+      Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::MachineLearning::Model.descendants : [klass.constantize]
+
+      models.each do |model|
+        spinner = TTY::Spinner.new(("Deleting #{model} ".ljust(JUSTIFICATION) + ":spinner"), format: :dots)
+        spinner.auto_spin
+        unless model.registered?
+          spinner.stop(Rainbow("[MISSING]").white)
+          next
+        end
+
+        model.delete
+
+        status = !model.registered? ? Rainbow("[DELETED]").green : Rainbow("[NOT DELETED]").yellow
+        spinner.stop(status)
+      end
+    end
+  end
+end

--- a/lib/stretchy/rails/tasks/ml/deploy.rake
+++ b/lib/stretchy/rails/tasks/ml/deploy.rake
@@ -1,0 +1,78 @@
+namespace :stretchy do
+  namespace :ml do
+
+    desc "Register the model ENV['MODEL']"
+    task register: :environment do
+      klass = ENV['MODEL']
+      Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::MachineLearning::Model.descendants : [klass.constantize]
+
+      models.each do |model|
+        spinner = TTY::Spinner.new(("Registering #{model} ".ljust(JUSTIFICATION) + ":spinner"), format: :dots)
+        spinner.auto_spin
+        if model.registered?
+          spinner.stop(Rainbow("[SUCCESS]").green)
+          next
+        end
+
+        model.register do  |m|
+          m.wait_until_complete do
+            m.registered?
+          end
+        end
+
+        status = model.registered? ? Rainbow("[SUCCESS]").green : Rainbow("[FAILED]").red
+        spinner.stop(status)
+      end
+    end
+
+    desc "Undeploy the model ENV['MODEL']"
+    task undeploy: :environment do
+      klass = ENV['MODEL']
+      Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::MachineLearning::Model.descendants : [klass.constantize]
+      models.each do |model|
+        spinner = TTY::Spinner.new("Undeploying #{model} ". ljust(JUSTIFICATION) + ":spinner", format: :dots)
+        spinner.auto_spin
+
+        unless model.deployed?
+          spinner.stop(Rainbow("[NOT DEPLOYED]").white)
+          next
+        end
+
+        model.undeploy do |m|
+          m.wait_until_complete do
+            !m.deployed?
+          end
+        end
+        status = !model.deployed? ?  Rainbow("[SUCCESS]").green : Rainbow("[DEPLOYED]").yellow
+        spinner.stop(status)
+      end
+    end
+
+    desc "Deploy the model ENV['MODEL']"
+    task deploy: :environment do
+      klass = ENV['MODEL']
+      Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::MachineLearning::Model.descendants : [klass.constantize]
+      models.each do |model|
+        spinner = TTY::Spinner.new("Deploying #{model} ".ljust(JUSTIFICATION) + ":spinner", format: :dots)
+        spinner.auto_spin
+
+        if model.deployed?
+          spinner.stop(Rainbow("[SUCCESS]").green)
+          next
+        end
+
+        model.deploy do |m|
+          m.wait_until_complete do
+            m.deployed?
+          end
+        end
+        status = model.deployed? ? Rainbow("[SUCCESS]").green : Rainbow("[FAILED]").red 
+        spinner.stop(status)
+      end
+    end
+
+  end
+end

--- a/lib/stretchy/rails/tasks/ml/status.rake
+++ b/lib/stretchy/rails/tasks/ml/status.rake
@@ -4,29 +4,25 @@ namespace :stretchy do
     desc "Check the status of all pipelines"
     task status: :environment do
       klass = ENV['MODEL']
-      unless klass.nil?
-        klass = klass.constantize
-      end
 
       Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::MachineLearning::Model.descendants : [klass.constantize]
 
-      puts Rainbow("MachineLearning").color :gray
-      Stretchy::MachineLearning::Model.descendants.each do |klass|
+      puts Rainbow("Machine Learning").color :gray
+      models.each do |model|
         
-        response = "FAILED"#klass.client.get_model(id: 'm9G-gI4BMe6MfgkYifM9').dig('model_state')
-        status = if response
-          case response
+        response = model.find['model_state']
+        status = case response
           when 'DEPLOYED'
             Rainbow("[#{response}]").green.bright
-          when 'FAILED'
+          when 'DEPLOY_FAILED'
             Rainbow("[#{response}]").red.bright
           when 'CREATED'
             Rainbow("[#{response}]").yellow.bright
-          end
         else
-          Rainbow("[MISSING]").white.dim
+          Rainbow("[MISSING]").white
         end
-        puts "#{klass}".ljust(60) + status
+        puts "#{model}".ljust(JUSTIFICATION) + status
       end
       puts "\n\n"
     end

--- a/lib/stretchy/rails/tasks/ml/status.rake
+++ b/lib/stretchy/rails/tasks/ml/status.rake
@@ -1,0 +1,35 @@
+namespace :stretchy do
+  namespace :ml do
+
+    desc "Check the status of all pipelines"
+    task status: :environment do
+      klass = ENV['MODEL']
+      unless klass.nil?
+        klass = klass.constantize
+      end
+
+      Rails.application.eager_load!
+
+      puts Rainbow("MachineLearning").color :gray
+      Stretchy::MachineLearning::Model.descendants.each do |klass|
+        
+        response = "FAILED"#klass.client.get_model(id: 'm9G-gI4BMe6MfgkYifM9').dig('model_state')
+        status = if response
+          case response
+          when 'DEPLOYED'
+            Rainbow("[#{response}]").green.bright
+          when 'FAILED'
+            Rainbow("[#{response}]").red.bright
+          when 'CREATED'
+            Rainbow("[#{response}]").yellow.bright
+          end
+        else
+          Rainbow("[MISSING]").white.dim
+        end
+        puts "#{klass}".ljust(60) + status
+      end
+      puts "\n\n"
+    end
+
+  end
+end

--- a/lib/stretchy/rails/tasks/pipeline/create.rake
+++ b/lib/stretchy/rails/tasks/pipeline/create.rake
@@ -1,0 +1,27 @@
+namespace :stretchy do
+  namespace :pipeline do
+    desc "Create pipeline"
+    task create: :environment do
+      klass = ENV['MODEL']
+      models = klass.nil? ? Stretchy::Pipeline.descendants : [klass.constantize]
+        models.each do |model|
+          spinner = TTY::Spinner.new("Creating Pipeline #{model} ".ljust(JUSTIFICATION) + ":spinner", format: :dots)
+          spinner.auto_spin
+
+          begin
+            response = model.create!
+          rescue => e
+            spinner.stop(Rainbow("[FAILED]").red)
+            puts e.message
+            next
+          end
+          status = if response['acknowledged']
+            Rainbow("[SUCCESS]").green
+          else
+            Rainbow("[FAILED]").red
+          end
+          spinner.stop(status)
+        end
+      end
+  end
+end

--- a/lib/stretchy/rails/tasks/pipeline/delete.rake
+++ b/lib/stretchy/rails/tasks/pipeline/delete.rake
@@ -1,0 +1,26 @@
+namespace :stretchy do
+  namespace :pipeline do
+    desc "Delete pipeline"
+    task delete: :environment do
+      klass = ENV['MODEL']
+      models = klass.nil? ? Stretchy::Pipeline.descendants : [klass.constantize]
+        models.each do |model|
+          spinner = TTY::Spinner.new("Deleting Pipeline #{model} ".ljust(JUSTIFICATION) + ":spinner", format: :dots)
+          spinner.auto_spin
+
+          unless model.exists?
+            spinner.stop(Rainbow("[MISSING]").white)
+            next
+          end
+
+          response = model.delete!
+          status = if response['acknowledged']
+            Rainbow("[SUCCESS]").green
+          else
+            Rainbow("[FAILED]").red
+          end
+          spinner.stop(status)
+        end
+      end
+  end
+end

--- a/lib/stretchy/rails/tasks/pipeline/status.rake
+++ b/lib/stretchy/rails/tasks/pipeline/status.rake
@@ -1,0 +1,27 @@
+namespace :stretchy do
+  namespace :pipeline do
+
+    desc "Check the status of all pipelines"
+    task status: :environment do
+      klass = ENV['MODEL']
+      unless klass.nil?
+        klass = klass.constantize
+      end
+
+      Rails.application.eager_load!
+
+      puts Rainbow("Pipelines").color :gray
+      Stretchy::Pipeline.descendants.each do |klass|
+        response = klass.exists?
+        status = if response
+          Rainbow("[CREATED]").green.bright
+        else
+          Rainbow("[MISSING]").gray.bright
+        end
+        puts "#{klass.pipeline_name}".ljust(60) + status
+      end
+      puts "\n\n"
+    end
+
+  end
+end

--- a/lib/stretchy/rails/tasks/pipeline/status.rake
+++ b/lib/stretchy/rails/tasks/pipeline/status.rake
@@ -4,21 +4,19 @@ namespace :stretchy do
     desc "Check the status of all pipelines"
     task status: :environment do
       klass = ENV['MODEL']
-      unless klass.nil?
-        klass = klass.constantize
-      end
 
       Rails.application.eager_load!
+      models = klass.nil? ? Stretchy::Pipeline.descendants : [klass.constantize]
 
       puts Rainbow("Pipelines").color :gray
-      Stretchy::Pipeline.descendants.each do |klass|
-        response = klass.exists?
+      models.each do |model|
+        response = model.exists?
         status = if response
           Rainbow("[CREATED]").green.bright
         else
-          Rainbow("[MISSING]").gray.bright
+          Rainbow("[MISSING]").white
         end
-        puts "#{klass.pipeline_name}".ljust(60) + status
+        puts "#{model.pipeline_name}".ljust(JUSTIFICATION) + status
       end
       puts "\n\n"
     end

--- a/lib/stretchy/rails/tasks/status.rake
+++ b/lib/stretchy/rails/tasks/status.rake
@@ -1,0 +1,21 @@
+namespace :stretchy do
+  namespace :status do
+    desc "Check the status of all indexes"
+    task all: :environment do
+      klass = ENV['MODEL']
+      unless klass.nil?
+        klass = klass.constantize
+      end
+
+      Rake::Task['stretchy:index:status'].invoke
+      Rake::Task['stretchy:pipeline:status'].invoke
+      Rake::Task['stretchy:ml:status'].invoke
+
+
+    end
+  end
+
+  desc "Check the status of all indexes, pipelines and ml models"
+  task status: 'stretchy:status:all' do
+  end
+end

--- a/lib/stretchy/rails/tasks/status.rake
+++ b/lib/stretchy/rails/tasks/status.rake
@@ -2,16 +2,9 @@ namespace :stretchy do
   namespace :status do
     desc "Check the status of all indexes"
     task all: :environment do
-      klass = ENV['MODEL']
-      unless klass.nil?
-        klass = klass.constantize
-      end
-
       Rake::Task['stretchy:index:status'].invoke
       Rake::Task['stretchy:pipeline:status'].invoke
       Rake::Task['stretchy:ml:status'].invoke
-
-
     end
   end
 

--- a/lib/stretchy/rails/tasks/stretchy.rake
+++ b/lib/stretchy/rails/tasks/stretchy.rake
@@ -1,0 +1,4 @@
+require 'stretchy-model'
+
+path = File.expand_path(__dir__)
+Dir.glob("#{path}/**/*.rake").each { |f| import f }

--- a/lib/stretchy/rails/tasks/stretchy.rake
+++ b/lib/stretchy/rails/tasks/stretchy.rake
@@ -1,4 +1,23 @@
 require 'stretchy-model'
+require 'tty-spinner'
+
+JUSTIFICATION = 90 unless defined?(JUSTIFICATION)
 
 path = File.expand_path(__dir__)
 Dir.glob("#{path}/**/*.rake").each { |f| import f }
+namespace :stretchy do
+  desc "Create all indexes, pipelines and deploy all models"
+  task up: :environment do
+    Rake::Task['stretchy:ml:register'].invoke
+    Rake::Task['stretchy:ml:deploy'].invoke
+    Rake::Task['stretchy:pipeline:create'].invoke
+    Rake::Task['stretchy:index:create'].invoke
+  end
+
+  task down: :environment do
+    Rake::Task['stretchy:ml:undeploy'].invoke
+    Rake::Task['stretchy:ml:delete'].invoke
+    Rake::Task['stretchy:pipeline:delete'].invoke
+    Rake::Task['stretchy:index:delete'].invoke
+  end
+end

--- a/spec/features/ml_model_integration_spec.rb
+++ b/spec/features/ml_model_integration_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe 'ML Model', opensearch_only: true, type: :integration do
   before(:all) do
-    @sparse_model = Stretchy::MachineLearning::Model.new(
-      model: :neural_sparse_encoding,
-      version: '1.0.1',
-      model_format: 'TORCH_SCRIPT',
-      description: 'Creates sparse embedding for onboarding docs'
-    )
+    @sparse_model = SparseEmbeddingModel = Class.new(Stretchy::MachineLearning::Model) do
+      model :neural_sparse_encoding
+      version '1.0.1'
+      model_format 'TORCH_SCRIPT'
+      description 'Creates sparse embedding for onboarding docs'
+    end
     Stretchy::MachineLearning::Model.ml_on_all_nodes!
 
     @sparse_model.register do |model|
-      model.wait_until_complete do
+      model.wait_until_complete(max_attempts: 30, sleep_time: 5) do
         Stretchy.logger.debug "Registering model #{model.model}"
         model.registered?
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+ENV['RACK_ENV'] = 'test'
+
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'

--- a/spec/stretchy/machine_learning/model_spec.rb
+++ b/spec/stretchy/machine_learning/model_spec.rb
@@ -119,8 +119,8 @@ describe Stretchy::MachineLearning::Model do
 
       context 'not deployed' do
         it 'should check if deployed' do
-          # described_class.registry.delete
           model.instance_variable_set(:@deployed, nil)
+          allow(model).to receive(:model_id).and_return('78910')
           allow(model).to receive(:registry).and_return(double('Registry', model_id: '78910'))
           allow(model.client).to receive(:get_model).with(id: '78910').and_return(status_deploying)
           expect(model.deployed?).to be_falsey

--- a/spec/stretchy/machine_learning/model_spec.rb
+++ b/spec/stretchy/machine_learning/model_spec.rb
@@ -10,27 +10,13 @@ describe Stretchy::MachineLearning::Model do
     expect(described_class.model_lookup :neural_sparse_encoding).to eq('amazon/neural-sparse/opensearch-neural-sparse-encoding-v1')
   end
 
-  context 'model name' do
-    it 'should have a model name' do
-      model = described_class.new(model: 'great-model')
-      expect(model.model).to eq('great-model')
-    end
-    
-    it 'should lookup short names' do
-      model = described_class.new model: :neural_sparse_encoding
-      expect(model.model).to eq('amazon/neural-sparse/opensearch-neural-sparse-encoding-v1')
-    end
-
-  end
-
   context 'api' do
     let(:model) {  
-      described_class.new(
-        model: :neural_sparse_encoding, 
-        version: '1.0.1', 
-        model_format: 'TORCH_SCRIPT', 
-        description: 'A great model'
-      )
+      TestEmbedding ||= Class.new(Stretchy::MachineLearning::Model) do
+        model :sentence_transformers_minilm_12
+        model_format 'TORCH_SCRIPT'
+        version '1.0.1'
+      end
     }
 
     let(:status_complete) {
@@ -58,6 +44,19 @@ describe Stretchy::MachineLearning::Model do
       end
     end
 
+    context 'standalone' do
+      it 'has model' do
+        expect(model.model).to eq('huggingface/sentence-transformers/all-MiniLM-L12-v2')
+      end
+
+      it 'has version' do
+        expect(model.version).to eq('1.0.1')
+      end
+
+      it 'has model format' do
+        expect(model.model_format).to eq('TORCH_SCRIPT')
+      end
+    end
 
     context 'register' do
       before(:each) do
@@ -114,14 +113,15 @@ describe Stretchy::MachineLearning::Model do
       end
 
       it 'should check if deployed' do
-        allow(model).to receive(:model_id).and_return('78910')
-        allow(model.client).to receive(:get_model).with(id: '78910').and_return(status_deployed)
+        allow(model.client).to receive(:get_model).and_return(status_deployed)
         expect(model.deployed?).to be_truthy
       end
 
       context 'not deployed' do
         it 'should check if deployed' do
-          allow(model).to receive(:model_id).and_return('78910')
+          # described_class.registry.delete
+          model.instance_variable_set(:@deployed, nil)
+          allow(model).to receive(:registry).and_return(double('Registry', model_id: '78910'))
           allow(model.client).to receive(:get_model).with(id: '78910').and_return(status_deploying)
           expect(model.deployed?).to be_falsey
         end

--- a/spec/stretchy/machine_learning/registery_spec.rb
+++ b/spec/stretchy/machine_learning/registery_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Stretchy::MachineLearning::Registry do
+
+  context 'index' do
+    it 'should have an index' do
+      Stretchy::MachineLearning::Registry.create_index!
+      expect(Stretchy::MachineLearning::Registry.index_exists?).to be true
+      expect(Stretchy::MachineLearning::Registry.index_name).to eq('.stretchy_ml_registry_test')
+    end
+  end
+
+  context 'registers' do
+    before(:each) do
+      Stretchy::MachineLearning::Registry.delete_index! if Stretchy::MachineLearning::Registry.index_exists?
+    end
+
+    it 'should create the index' do
+      allow(Stretchy::MachineLearning::Registry).to receive(:create_index!).and_call_original
+      described_class.register(class_name: 'Stretchy::MachineLearning::Model')
+      expect(Stretchy::MachineLearning::Registry).to have_received(:create_index!).once
+      expect(Stretchy::MachineLearning::Registry.index_exists?).to be true
+    end
+
+    it 'finds or creates a model' do
+      allow(Stretchy::MachineLearning::Registry).to receive(:create).and_call_original
+      first_registry = described_class.register(class_name: 'Stretchy::MachineLearning::Model'.underscore)
+      found = described_class.register(class_name: 'Stretchy::MachineLearning::Model'.underscore)
+      expect(Stretchy::MachineLearning::Registry).to have_received(:create).once
+
+      expect(found.id).to eq(first_registry.id)
+    end
+
+    it 'updates a model' do
+      model = described_class.register(class_name: 'Stretchy::MachineLearning::Model')
+      model.update(model_id: '1234')
+      expect(described_class.find(model.id).model_id).to eq('1234')
+    end
+
+  end
+
+end

--- a/stretchy-model.gemspec
+++ b/stretchy-model.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "amazing_print", "~> 1.3"
   spec.add_dependency "jbuilder", "~> 2.11"
   spec.add_dependency "virtus", "~> 2.0"
+  spec.add_dependency "tty-spinner", "~> 0.9"
 
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "simplecov", "~> 0.21.2"


### PR DESCRIPTION
This pull request fixes two issues and adds new functionality to the codebase. The first issue (#112) is related to the creation of the `MachineLearning::Model::Registry` class. 

It allows tracking ML model deployment in stretchy apps. 

The second issue (#113) involves the addition of rake tasks to manage indices, pipelines, and models. This pull request adds several rake tasks to perform various operations such as checking the status of indices, pipelines, and ML models, registering and deploying ML models, creating and deleting indices and pipelines, and more. These rake tasks provide convenient command-line tools for managing the Elasticsearch functionality in the codebase.

The commits included in this pull request are:

- Fix #112 Create MachineLearning::Model::Registry

- Fix #113 Add rake tasks to manage indices, pipelines and models

Please review the changes and let me know if any further modifications are required.